### PR TITLE
Fix mermaid diagram syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ graph TB
 
     LB[Load Balancer<br/>TLS Termination]
 
-    subgraph Enclave Cluster — 3-of-5 Threshold
+    subgraph EnclaveCluster["Enclave Cluster — 3-of-5 Threshold"]
         E1[Enclave Node 1<br/>AMD SEV-SNP<br/>Azure]
         E2[Enclave Node 2<br/>AMD SEV-SNP<br/>Azure]
         E3[Enclave Node 3<br/>AMD SEV-SNP<br/>GCP]


### PR DESCRIPTION
The em dash (—) in the unquoted subgraph label
`subgraph Enclave Cluster — 3-of-5 Threshold` causes a mermaid lexical parsing error, preventing the diagram from rendering on GitHub. Use the quoted bracket syntax instead:
`subgraph EnclaveCluster["Enclave Cluster — 3-of-5 Threshold"]`

All 41 mermaid diagrams across the repository were validated — this was the only error.

https://claude.ai/code/session_01Qy5DFCe4ALbXf1wexanucX