### PR TITLE
Adopt immutable software + ephemeral key model (Phase 2)

### DIFF
--- a/docs/05-operations-and-deployment.md
+++ b/docs/05-operations-and-deployment.md
@@ -2,7 +2,7 @@
 
 > **CC-TSA Design Document 05** | Audience: Platform Engineers, SREs, Security Operations
 
-This document provides the complete operational guide for deploying, operating, and maintaining a Confidential Computing Timestamp Authority (CC-TSA) cluster. It covers infrastructure requirements, deployment topologies, DKG ceremony procedures, day-to-day operations, rolling updates, node replacement, incident response, backup and disaster recovery, and compliance mapping.
+This document provides the complete operational guide for deploying, operating, and maintaining a Confidential Computing Timestamp Authority (CC-TSA) cluster. It covers infrastructure requirements, deployment topologies, DKG ceremony procedures, day-to-day operations, software version changes, node replacement, incident response, backup and disaster recovery, and compliance mapping.
 
 For the overall system architecture, see [Architecture Overview](01-architecture-overview.md). For failure scenarios and recovery procedures, see [Failure Modes and Recovery](04-failure-modes-and-recovery.md). For the threshold cryptography underpinning key management, see [Quantum-Safe Threshold Cryptography](03-quantum-safe-threshold-crypto.md).
 
@@ -14,7 +14,7 @@ For the overall system architecture, see [Architecture Overview](01-architecture
 2. [Deployment Topology Options](#2-deployment-topology-options)
 3. [DKG Ceremony Procedure](#3-dkg-ceremony-procedure)
 4. [Day-to-Day Operations](#4-day-to-day-operations)
-5. [Rolling Update Procedure](#5-rolling-update-procedure)
+5. [Software Version Change Procedure](#5-software-version-change-procedure)
 6. [Node Replacement](#6-node-replacement)
 7. [Incident Response Playbooks](#7-incident-response-playbooks)
 8. [Backup & Disaster Recovery](#8-backup--disaster-recovery)
@@ -33,29 +33,25 @@ This section specifies the hardware, key management, networking, and time source
 | Enclave Nodes (5) | AMD EPYC Genoa (9004+) with SEV-SNP + SecureTSC | Azure: DCasv5-series; GCP: C3D confidential VMs |
 | vCPUs per node | 4-8 vCPUs | Threshold signing is not CPU-intensive |
 | Memory per node | 16-32 GB | Key shares and signing operations fit in <1 GB; extra for OS and application |
-| Disk per node | 64 GB SSD | OS, application, sealed key share blobs, logs |
-| Cold standby nodes | 2 (pre-provisioned, powered off) | One per primary provider (Azure, GCP) |
+| Disk per node | 64 GB SSD | OS, application, logs |
 
 SecureTSC is a hard requirement. It is available only on AMD EPYC 9004 (Genoa) and later processors. Azure DCasv5/ECasv5 series and GCP C3D confidential VMs support SecureTSC. See [Confidential Computing & Time](02-confidential-computing-and-time.md) for SecureTSC details.
 
-Cold standby nodes are pre-provisioned CVMs with the same application image, held powered off. They do not hold key shares until activated. Their purpose is to accelerate recovery from node failures -- see [Section 6](#6-node-replacement) for activation procedures.
-
 ### 1.2 Key Management
 
-| Component | Service | Notes |
-|---|---|---|
-| Azure KMS | Azure Key Vault with Managed HSM (MHSM) | Supports Secure Key Release conditioned on SEV-SNP attestation |
-| GCP KMS | GCP Cloud KMS (Confidential Key Management) | Supports Confidential Key Release conditioned on SEV-SNP attestation |
-| Key type | RSA or AES wrapping key | Used to wrap/unwrap the outer envelope of sealed key shares |
+Key shares exist **only in enclave memory**. There is no at-rest persistence, no KMS wrapping, and no sealed key share blobs. This is the fundamental design property of the CC-TSA key management model.
 
-Each enclave node's key share is sealed using a **double-envelope encryption** scheme:
+| Property | Detail |
+|---|---|
+| Key share location | Enclave memory only (hardware-encrypted by AMD SEV-SNP) |
+| At-rest persistence | None — key shares are never written to disk or cloud storage |
+| Survival across reboot | No — if a node reboots, its key share is irrecoverably lost |
+| Recovery from quorum loss | New DKG ceremony + new certificate issuance |
+| External key management dependencies | None — no cloud KMS, no wrapping keys, no attestation policy management |
 
-1. **Inner envelope**: The key share is encrypted with a key derived from the enclave's hardware sealing identity (AMD-SP derived key, specific to the measurement and platform).
-2. **Outer envelope**: The inner-sealed blob is further encrypted by the provider's KMS wrapping key, which is released only to enclaves passing attestation verification.
+This model eliminates the attack surface associated with at-rest key material: there are no sealed blobs to steal, no wrapping keys to compromise, and no KMS attestation policies that an operator could misconfigure or an attacker could subvert. Trust is rooted entirely in the hardware attestation of the running enclave and the software measurement bound to the TSA certificate.
 
-This means that unsealing requires both (a) running on the correct hardware with the correct measurement (inner envelope) and (b) the KMS releasing the wrapping key after verifying the attestation report (outer envelope). Neither the KMS operator nor a compromised enclave with a different measurement can unseal the share.
-
-See [Quantum-Safe Threshold Cryptography](03-quantum-safe-threshold-crypto.md) for the full key lifecycle.
+See [Quantum-Safe Threshold Cryptography](03-quantum-safe-threshold-crypto.md) for the full key lifecycle and the rationale for the ephemeral model.
 
 ### 1.3 Networking
 
@@ -63,7 +59,6 @@ See [Quantum-Safe Threshold Cryptography](03-quantum-safe-threshold-crypto.md) f
 |---|---|
 | Node-to-node | Mutual TLS (mTLS) with certificates attested during DKG; low latency (<5ms RTT recommended within a provider, <30ms RTT cross-provider) |
 | Node-to-NTS | Outbound to 4+ NTS servers; UDP 123 (NTP) + TCP 4460 (NTS-KE) |
-| Node-to-KMS | Outbound to Azure Key Vault / GCP Cloud KMS API endpoints (HTTPS 443) |
 | Load balancer to nodes | HTTPS (TLS 1.3); health check endpoint on each node |
 | Client-facing | HTTPS on port 443; RFC 3161 HTTP transport (POST to `/timestamp` endpoint) |
 
@@ -90,12 +85,12 @@ CC-TSA supports three deployment topologies. The multi-provider topology is **re
 
 ### 2.1 Option A: Single Provider (Azure)
 
-| Region | AZ | Nodes | KMS |
-|---|---|---|---|
-| East US | AZ1 | Node 1, Node 2 | Key Vault MHSM (East US) |
-| East US | AZ2 | Node 3 | -- |
-| West US | AZ1 | Node 4 | Key Vault MHSM (West US) |
-| West US | AZ2 | Node 5 | -- |
+| Region | AZ | Nodes |
+|---|---|---|
+| East US | AZ1 | Node 1, Node 2 |
+| East US | AZ2 | Node 3 |
+| West US | AZ1 | Node 4 |
+| West US | AZ2 | Node 5 |
 
 **Pros:**
 - Simple operations: single provider relationship, single billing, unified tooling
@@ -109,11 +104,11 @@ CC-TSA supports three deployment topologies. The multi-provider topology is **re
 
 ### 2.2 Option B: Multi-Provider (Recommended)
 
-| Provider | Region | Nodes | KMS |
-|---|---|---|---|
-| Azure | East US (2 AZs) | Node 1, Node 2 | Azure Key Vault MHSM |
-| GCP | us-central1 (2 zones) | Node 3, Node 4 | GCP Cloud KMS |
-| Third Provider | Provider region | Node 5 | Provider KMS or Azure/GCP KMS via cross-provider access |
+| Provider | Region | Nodes |
+|---|---|---|
+| Azure | East US (2 AZs) | Node 1, Node 2 |
+| GCP | us-central1 (2 zones) | Node 3, Node 4 |
+| Third Provider | Provider region | Node 5 |
 
 **Pros:**
 - No single provider hosts 3 or more nodes (the threshold): maximum resilience against provider-level compromise
@@ -127,13 +122,13 @@ CC-TSA supports three deployment topologies. The multi-provider topology is **re
 
 ### 2.3 Option C: Triple-Provider (Maximum Resilience)
 
-| Provider | Nodes | KMS |
-|---|---|---|
-| Azure | Node 1, Node 2 | Azure Key Vault MHSM |
-| GCP | Node 3, Node 4 | GCP Cloud KMS |
-| OCI / IBM / other | Node 5 | Provider KMS |
+| Provider | Nodes |
+|---|---|
+| Azure | Node 1, Node 2 |
+| GCP | Node 3, Node 4 |
+| OCI / IBM / other | Node 5 |
 
-This is a specific case of Option B where the third provider is a full-capability confidential computing provider (e.g., Oracle Cloud Infrastructure with AMD SEV-SNP support). The distinction from Option B is that the third provider supplies its own native KMS with attestation-based key release, rather than relying on Azure or GCP KMS for the fifth node's key share.
+This is a specific case of Option B where the third provider is a full-capability confidential computing provider (e.g., Oracle Cloud Infrastructure with AMD SEV-SNP support). The distinction from Option B is that the third provider supplies its own native confidential computing infrastructure with AMD SEV-SNP attestation support.
 
 ### 2.4 Recommendation Matrix
 
@@ -142,7 +137,7 @@ This is a specific case of Option B where the third provider is a full-capabilit
 | Resilience | Moderate | High | Highest |
 | Operational complexity | Low | Moderate | High |
 | Cost | Lower | Moderate | Higher |
-| Trust model | Single provider trust | No provider >= threshold | No provider >= threshold, diverse KMS |
+| Trust model | Single provider trust | No provider >= threshold | No provider >= threshold, diverse infrastructure |
 | Cross-provider latency | None (intra-provider) | 10-30ms for signing rounds | 10-30ms for signing rounds |
 | **Recommendation** | Dev/staging only | **Production** | High-assurance use cases |
 
@@ -165,7 +160,6 @@ graph TB
             N2["Node 2<br/>DCasv5 SEV-SNP<br/>Key Share 2"]
         end
         ALB["Azure Load Balancer"]
-        AKMS["Azure Key Vault<br/>Managed HSM"]
     end
 
     subgraph GCPRegion["GCP — us-central1"]
@@ -177,12 +171,10 @@ graph TB
             N4["Node 4<br/>C3D SEV-SNP<br/>Key Share 4"]
         end
         GLBN["GCP Load Balancer"]
-        GKMS["GCP Cloud KMS"]
     end
 
     subgraph ThirdProvider["Third Provider"]
         N5["Node 5<br/>SEV-SNP CVM<br/>Key Share 5"]
-        TKMS["Provider KMS<br/>or Azure/GCP KMS"]
     end
 
     subgraph NTSSources["NTS Time Sources"]
@@ -205,10 +197,6 @@ graph TB
     ALB --> N2
     GLBN --> N3
     GLBN --> N4
-
-    N1 & N2 -.->|"Secure Key Release"| AKMS
-    N3 & N4 -.->|"Attestation-based Release"| GKMS
-    N5 -.->|"Secure Key Release"| TKMS
 
     N1 <-->|"mTLS mesh"| N2
     N1 <-->|"mTLS mesh"| N3
@@ -242,28 +230,45 @@ graph TB
 - **No single provider holds >= 3 nodes**: Azure has 2, GCP has 2, third provider has 1. A complete compromise of any single provider yields at most 2 key shares -- below the threshold of 3.
 - **Cross-provider mesh**: All 5 nodes maintain mTLS connections to all peers for threshold signing, TriHaRd time exchange, and health checks.
 - **Independent NTS queries**: Each node independently queries all 4 NTS sources. There is no shared NTP proxy or single point of failure for time.
-- **Per-provider KMS**: Each node's key share is sealed by the KMS of the provider hosting that node. The KMS releases the wrapping key only after verifying the node's SEV-SNP attestation report.
+- **Ephemeral key shares**: Key shares exist only in enclave memory. There is no at-rest key material, no KMS dependency, and no sealed blobs to manage. Trust is rooted in the hardware attestation of the running enclave.
 
 ---
 
 ## 3. DKG Ceremony Procedure
 
-Distributed Key Generation (DKG) is the foundational ceremony that creates the TSA signing key distributed across the 5 enclave nodes. Each node receives one key share; the complete signing key never exists in any single location.
+Distributed Key Generation (DKG) is the routine operation that creates a TSA signing key distributed across the 5 enclave nodes. Each node receives one key share; the complete signing key never exists in any single location.
+
+Unlike traditional key ceremonies that occur once and produce long-lived keys, DKG in CC-TSA is a **routine operational procedure** that runs every time the cluster is constituted or reconstituted. Because key shares are ephemeral (memory-only), DKG is the mechanism by which the cluster transitions from "nodes running" to "nodes ready to sign."
 
 See [Quantum-Safe Threshold Cryptography](03-quantum-safe-threshold-crypto.md) for the mathematical protocol. This section covers the operational procedure.
 
-### 3.1 Prerequisites
+### 3.1 When DKG Runs
+
+DKG is required in the following situations:
+
+| Trigger | Description |
+|---|---|
+| **Initial deployment** | First-time cluster setup — no key material exists yet |
+| **Software version change** | Any change to the application image produces a new attestation measurement, requiring a new key and certificate (see [Section 5](#5-software-version-change-procedure)) |
+| **Quorum loss** | If fewer than 3 nodes remain running, all key shares are effectively lost and a new DKG is required after nodes are restored |
+| **Certificate renewal** | When the TSA certificate approaches expiry, a new DKG produces a new key and certificate (rather than re-certifying an existing key, since the key exists only in memory) |
+| **Planned key rotation** | Periodic key rotation per organizational policy (e.g., annually) |
+| **Security incident** | If key compromise is suspected, a new DKG with a new key provides a clean start |
+
+DKG is designed to be a **fast, automated, low-risk operation** — not a rare ceremony requiring exceptional preparation. Operators should be comfortable running DKG as part of routine maintenance.
+
+### 3.2 Prerequisites
 
 Before initiating DKG, all of the following must be in place:
 
 - All 5 enclave nodes provisioned, booted, and passing health checks
-- KMS configured with attestation policies (expected measurement, VM policy, minimum firmware version)
+- All nodes running the same software image (identical attestation measurement)
 - Network connectivity between all nodes verified (mTLS handshake successful between every pair)
 - Certificate Authority ready to issue the TSA certificate (CA operator available if manual approval required)
 - At least 2 operators present for 4-eyes principle (dual authorization)
 - DKG ceremony log initialized (append-only transcript for audit)
 
-### 3.2 DKG Ceremony Flow
+### 3.3 DKG Ceremony Flow
 
 ```mermaid
 flowchart TD
@@ -318,18 +323,11 @@ flowchart TD
         CERT5["Certificate distributed<br/>to all 5 nodes"]
     end
 
-    subgraph Seal["Phase 8: Key Share Sealing"]
-        SEAL1["Each node seals its key share<br/>using double-envelope encryption"]
-        SEAL2["Inner: enclave hardware sealing key<br/>Outer: KMS wrapping key"]
-        SEAL3["Sealed blobs stored on<br/>persistent durable storage"]
-        SEAL4["Verify: each node can<br/>unseal its own share"]
-    end
-
-    subgraph Complete["Phase 9: Ceremony Completion"]
+    subgraph Complete["Phase 8: Ceremony Completion"]
         COMP1["Coordinator broadcasts<br/>'DKG complete' to all nodes"]
-        COMP2["All nodes transition<br/>to Active state"]
+        COMP2["All nodes transition to Active state<br/>(key shares held in memory only)"]
         COMP3["Operator verifies: test<br/>timestamp request succeeds"]
-        COMP4["Archive ceremony transcript<br/>(attestation reports, commitments,<br/>certificate, operator signatures)"]
+        COMP4["Archive ceremony transcript<br/>(attestation reports, commitments,<br/>certificate, measurement, operator signatures)"]
     end
 
     ABORT(["ABORT DKG<br/>Investigate and retry"])
@@ -373,12 +371,7 @@ flowchart TD
     CERT2 --> CERT3
     CERT3 --> CERT4
     CERT4 --> CERT5
-    CERT5 --> SEAL1
-
-    SEAL1 --> SEAL2
-    SEAL2 --> SEAL3
-    SEAL3 --> SEAL4
-    SEAL4 --> COMP1
+    CERT5 --> COMP1
 
     COMP1 --> COMP2
     COMP2 --> COMP3
@@ -392,13 +385,12 @@ flowchart TD
     style Round2 fill:#f3e5f5,stroke:#9c27b0,stroke-width:2px
     style PubKey fill:#e8f5e9,stroke:#4caf50,stroke-width:2px
     style Cert fill:#fce4ec,stroke:#e91e63,stroke-width:2px
-    style Seal fill:#fff8e1,stroke:#ffc107,stroke-width:2px
     style Complete fill:#e8f5e9,stroke:#4caf50,stroke-width:2px
     style ABORT fill:#ffcdd2,stroke:#f44336,stroke-width:2px
     style DONE fill:#c8e6c9,stroke:#4caf50,stroke-width:2px
 ```
 
-### 3.3 Phase Details
+### 3.4 Phase Details
 
 **Phase 1 -- Pre-Flight Checks.** The operator verifies that all infrastructure is ready. Each node's health endpoint must return OK, confirming the node is booted, attested, time-synchronized (TriHaRd validation passes), and able to communicate with all peers. If any check fails, the ceremony is postponed until the issue is resolved.
 
@@ -412,13 +404,28 @@ flowchart TD
 
 **Phase 6 -- Public Key Derivation.** All nodes independently compute the group public key from the polynomial commitments. The coordinator collects all 5 computed public keys and verifies they are identical. A mismatch indicates a protocol error or a malicious node.
 
-**Phase 7 -- Certificate Issuance.** The coordinator generates a Certificate Signing Request (CSR) containing the derived group public key, the TSA's distinguished name, the `id-kp-timeStamping` Extended Key Usage (OID 1.3.6.1.5.5.7.3.8), and the TSA policy OID. The CSR is submitted to the Certificate Authority. Depending on the CA, this may be automated (ACME-like) or require manual approval. The issued X.509 certificate is distributed to all 5 nodes.
+**Phase 7 -- Certificate Issuance.** The coordinator generates a Certificate Signing Request (CSR) containing the derived group public key, the TSA's distinguished name, the `id-kp-timeStamping` Extended Key Usage (OID 1.3.6.1.5.5.7.3.8), and the TSA policy OID. The CSR also records the attestation measurement of the enclave nodes, binding the certificate to the specific software version that generated the key. The CSR is submitted to the Certificate Authority. Depending on the CA, this may be automated (ACME-like) or require manual approval. The issued X.509 certificate is distributed to all 5 nodes.
 
-**Phase 8 -- Key Share Sealing.** Each node seals its key share using double-envelope encryption: the inner envelope uses the enclave's hardware sealing key (AMD-SP derived), and the outer envelope uses the provider KMS wrapping key. The sealed blob is written to persistent durable storage (Azure Blob Storage, GCS, or local SSD with backup). Each node verifies it can unseal its own share by performing a test unseal.
+**Phase 8 -- Ceremony Completion.** The coordinator broadcasts "DKG complete" to all nodes. All nodes transition from DKG mode to Active mode and begin accepting timestamp requests. Key shares remain in enclave memory only — they are not persisted to any durable storage. The operator verifies end-to-end functionality by submitting a test timestamp request and validating the response. The ceremony transcript (attestation reports, commitments, certificate, attestation measurement, operator signatures, timestamps) is archived to immutable storage for audit purposes.
 
-**Phase 9 -- Ceremony Completion.** The coordinator broadcasts "DKG complete" to all nodes. All nodes transition from DKG mode to Active mode and begin accepting timestamp requests. The operator verifies end-to-end functionality by submitting a test timestamp request and validating the response. The ceremony transcript (attestation reports, commitments, certificate, operator signatures, timestamps) is archived to immutable storage for audit purposes.
+### 3.5 Certificate Issuance as Part of DKG
 
-### 3.4 Estimated Duration
+Certificate issuance is an integral part of every DKG ceremony, not a separate process. Because the signing key is ephemeral and unique to each DKG, every DKG produces a new public key that requires a new certificate. The certificate binds together:
+
+- The **group public key** derived during DKG
+- The **attestation measurement** of the software running in the enclaves
+- The **TSA identity** (distinguished name, policy OID)
+
+This binding means that the certificate serves as a permanent, verifiable record of what software produced the signing key. Relying parties can verify that a timestamp was produced by enclaves running a specific, known software version.
+
+**Certificate lifecycle under the ephemeral model:**
+
+1. Each DKG ceremony produces a new key and a new certificate.
+2. The old certificate can be revoked or allowed to expire after the new one is active.
+3. Previously issued timestamps remain valid — they were signed with the old key, which was valid at the time of signing, and verifiers can validate against the old certificate.
+4. Certificate renewal without a software change still requires a new DKG, because the existing key shares cannot be exported from memory to produce a CSR.
+
+### 3.6 Estimated Duration
 
 | Phase | Duration | Notes |
 |---|---|---|
@@ -427,9 +434,8 @@ flowchart TD
 | Share generation + verification | 1-3 min | Two protocol rounds across 5 nodes |
 | Public key derivation | <30 sec | Local computation + comparison |
 | Certificate issuance | 1-5 min | Depends on CA (automated vs. manual) |
-| Key share sealing + verification | 1-2 min | KMS round-trips |
 | Completion + test | <1 min | Test timestamp request |
-| **Total** | **5-15 min** | Mostly automated, operator provides oversight and approval |
+| **Total** | **5-12 min** | Mostly automated, operator provides oversight and approval |
 
 ---
 
@@ -447,9 +453,8 @@ The following table defines the key operational metrics, their healthy ranges, a
 | Attestation status | All valid | 1 stale (>1h since last refresh) | Any invalid |
 | Signing latency (p99) | <50 ms | <200 ms | >= 200 ms |
 | Signing success rate | >99.9% | >99% | <99% |
-| Key share seal status | All sealed and verified | -- | Any seal verification failed |
+| Key shares in memory | All 5 nodes hold shares | 4 nodes hold shares | <=3 nodes hold shares |
 | Certificate validity | >30 days remaining | <30 days remaining | <7 days remaining |
-| KMS connectivity | All nodes connected | 1 node KMS timeout | >=2 nodes KMS unreachable |
 | Disk usage per node | <50% | <80% | >=80% |
 
 ```mermaid
@@ -515,25 +520,22 @@ stateDiagram-v2
     [*] --> Booting
 
     Booting --> Attesting: Boot complete
-    Attesting --> Unsealing: Attestation valid
+    Attesting --> Synchronizing: Attestation valid
     Attesting --> Failed: Attestation failed
-    Unsealing --> Synchronizing: Key share unsealed
-    Unsealing --> Failed: KMS rejected attestation
-    Synchronizing --> Active: TriHaRd sync complete,<br/>joined cluster
+    Synchronizing --> WaitingForDKG: TriHaRd sync complete,<br/>joined cluster
     Synchronizing --> TimeDrift: Drift > 50us
 
+    WaitingForDKG --> DKGMode: DKG initiated
+    DKGMode --> Active: DKG complete,<br/>key shares in memory
+
     Active --> Degraded: 1 node offline (4/5)
-    Degraded --> Active: Node recovered (5/5)
+    Degraded --> Active: Node recovered via new DKG (5/5)
     Degraded --> Critical: 2 nodes offline (3/5)
     Critical --> Degraded: 1 node recovered (4/5)
     Critical --> SigningHalted: 3rd node offline (<3/5)
-    SigningHalted --> Critical: Node recovered (3/5)
+    SigningHalted --> WaitingForDKG: Nodes restored,<br/>new DKG required
 
-    Active --> DKGMode: DKG initiated
-    DKGMode --> Active: DKG complete
-
-    Active --> Updating: Rolling update started
-    Updating --> Active: All nodes updated
+    Active --> DKGMode: Software change or<br/>key rotation initiated
 
     Active --> TimeDrift: Node drift > 50us
     TimeDrift --> Active: NTS resync, drift < 50us
@@ -548,152 +550,141 @@ stateDiagram-v2
     }
 
     style Active fill:#c8e6c9,stroke:#4caf50
+    style WaitingForDKG fill:#e8f4fd,stroke:#2196f3
     style Degraded fill:#fff9c4,stroke:#fbc02d
     style Critical fill:#ffcdd2,stroke:#e53935
     style SigningHalted fill:#ffcdd2,stroke:#c62828
     style Failed fill:#ffcdd2,stroke:#b71c1c
 ```
 
-### 4.4 Proactive Share Refresh
-
-Proactive share refresh is a periodic protocol that generates new key shares for the same underlying signing key, invalidating old shares. This limits the window of exposure if a key share is compromised.
-
-| Parameter | Value |
-|---|---|
-| Schedule | Every 30 days (configurable) |
-| Minimum participants | 3 nodes (threshold) |
-| Preferred participants | All 5 nodes (optimal) |
-| Signing downtime | None -- old shares remain valid until refresh completes |
-| Duration | 2-5 minutes (automated) |
-
-**Procedure:**
-
-1. Coordinator initiates share refresh protocol with all online nodes (minimum 3).
-2. Each participating node generates new random sub-shares (new polynomial, same degree).
-3. Nodes exchange sub-shares over attested mTLS channels.
-4. Each node combines new sub-shares to derive a new key share.
-5. Each node seals the new share using double-envelope encryption.
-6. Each node verifies: the new share produces valid partial signatures that combine to a valid signature under the existing public key.
-7. Old sealed share blobs are securely deleted.
-
-**Monitoring after refresh:**
-
-- Verify all participating nodes hold new shares (check share version counter).
-- Verify a test timestamp request succeeds.
-- Verify sealed share blobs are updated in durable storage.
-
-See [Quantum-Safe Threshold Cryptography](03-quantum-safe-threshold-crypto.md) for the proactive share refresh protocol details.
-
 ---
 
-## 5. Rolling Update Procedure
+## 5. Software Version Change Procedure
 
-Rolling updates allow upgrading the CC-TSA application across all 5 nodes without signing downtime. The key rule is: **never update more than 1 node at a time**, maintaining at least 4 nodes online throughout the process.
+Software version changes in CC-TSA are **coordinated key rotation procedures**, not rolling updates. Because the software measurement is bound to the TSA certificate (see [Architecture Overview](01-architecture-overview.md) Section 8), any change to the application image produces a new attestation measurement and requires a new DKG ceremony and new certificate.
 
-### 5.1 Rolling Update Sequence
+This is a deliberate design choice: there is never ambiguity about which software version signed a given timestamp. Each certificate corresponds to exactly one software measurement.
+
+### 5.1 Procedure Overview
+
+A software version change follows this sequence:
+
+1. **Prepare**: Build, test, and validate the new application image.
+2. **Halt signing**: Stop accepting timestamp requests on the current cluster.
+3. **Deploy**: Deploy the new image to all 5 nodes simultaneously.
+4. **Boot and attest**: All nodes boot with the new image and generate fresh attestation reports with the new measurement.
+5. **DKG**: Run a new DKG ceremony to generate new key shares and a new public key.
+6. **Certificate**: Obtain a new TSA certificate from the CA for the new public key.
+7. **Resume signing**: Begin accepting timestamp requests with the new key and certificate.
+8. **Retire old certificate**: Revoke or allow the old certificate to expire.
+
+### 5.2 Software Version Change Sequence
 
 ```mermaid
 sequenceDiagram
     participant Op as Operator
-    participant KMS as KMS<br/>(Azure + GCP)
-    participant N5 as Node 5<br/>(Third Provider)
-    participant N4 as Node 4<br/>(GCP)
-    participant N3 as Node 3<br/>(GCP)
-    participant N2 as Node 2<br/>(Azure)
+    participant CA as Certificate<br/>Authority
     participant N1 as Node 1<br/>(Azure)
+    participant N2 as Node 2<br/>(Azure)
+    participant N3 as Node 3<br/>(GCP)
+    participant N4 as Node 4<br/>(GCP)
+    participant N5 as Node 5<br/>(Third Provider)
     participant LB as Load Balancer
 
-    Note over Op,LB: Preparation Phase
+    Note over Op,LB: Phase 1 — Preparation
 
     Op->>Op: Build and test new application image
     Op->>Op: Compute new image measurement hash
-    Op->>KMS: Update attestation policies:<br/>accept BOTH old AND new measurements
-    KMS-->>Op: Policies updated
+    Op->>Op: Validate new image in staging environment
 
-    Note over Op,LB: Update Node 5 (Third Provider — lowest risk first)
+    Note over Op,LB: Phase 2 — Halt Signing
 
-    Op->>LB: Drain Node 5 from load balancer
-    LB-->>Op: Node 5 drained (4 nodes serving)
+    Op->>LB: Remove all nodes from load balancer
+    LB-->>Op: All nodes drained (signing halted)
+    LB->>LB: Return HTTP 503 to all clients
+    Op->>N1: Stop TSA application
+    Op->>N2: Stop TSA application
+    Op->>N3: Stop TSA application
+    Op->>N4: Stop TSA application
     Op->>N5: Stop TSA application
+    Note over N1,N5: Old key shares discarded<br/>(lost when application stops)
+
+    Note over Op,LB: Phase 3 — Deploy New Image
+
+    Op->>N1: Deploy new application image
+    Op->>N2: Deploy new application image
+    Op->>N3: Deploy new application image
+    Op->>N4: Deploy new application image
     Op->>N5: Deploy new application image
-    Op->>N5: Boot Node 5
-    N5->>KMS: Attestation (new measurement)
-    KMS-->>N5: Key share released (new measurement accepted)
-    N5->>N5: Unseal key share, rejoin cluster
-    Op->>N5: Verify health (TriHaRd, signing test)
-    Op->>LB: Add Node 5 back to load balancer
-    LB-->>Op: Node 5 serving (5 nodes online)
 
-    Note over Op,LB: Update Node 4 (GCP)
+    Note over Op,LB: Phase 4 — Boot and Verify
 
-    Op->>LB: Drain Node 4
-    LB-->>Op: Node 4 drained (4 nodes serving)
-    Op->>N4: Stop, deploy new image, boot
-    N4->>KMS: Attestation (new measurement)
-    KMS-->>N4: Key share released
-    N4->>N4: Unseal, rejoin cluster
-    Op->>N4: Verify health
-    Op->>LB: Add Node 4 back
-    LB-->>Op: 5 nodes online
+    Op->>N1: Boot node
+    Op->>N2: Boot node
+    Op->>N3: Boot node
+    Op->>N4: Boot node
+    Op->>N5: Boot node
+    N1->>N1: Attestation (new measurement)
+    N2->>N2: Attestation (new measurement)
+    N3->>N3: Attestation (new measurement)
+    N4->>N4: Attestation (new measurement)
+    N5->>N5: Attestation (new measurement)
+    Op->>Op: Verify all 5 nodes healthy,<br/>TriHaRd sync complete
 
-    Note over Op,LB: Update Node 3 (GCP)
+    Note over Op,LB: Phase 5 — DKG Ceremony
 
-    Op->>LB: Drain Node 3
-    Op->>N3: Stop, deploy new image, boot
-    N3->>KMS: Attestation + unseal + rejoin
-    Op->>N3: Verify health
-    Op->>LB: Add Node 3 back
+    Op->>N1: Initiate DKG
+    Note over N1,N5: Full DKG ceremony<br/>(mutual attestation, share generation,<br/>verification, public key derivation)
+    Note over N1,N5: New key shares held in<br/>enclave memory only
 
-    Note over Op,LB: Update Node 2 (Azure)
+    Note over Op,LB: Phase 6 — Certificate Issuance
 
-    Op->>LB: Drain Node 2
-    Op->>N2: Stop, deploy new image, boot
-    N2->>KMS: Attestation + unseal + rejoin
-    Op->>N2: Verify health
-    Op->>LB: Add Node 2 back
+    N1->>CA: CSR with new public key +<br/>new attestation measurement
+    CA->>N1: New X.509 TSA certificate
+    N1->>N2: Distribute new certificate
+    N1->>N3: Distribute new certificate
+    N1->>N4: Distribute new certificate
+    N1->>N5: Distribute new certificate
 
-    Note over Op,LB: Update Node 1 (Azure)
+    Note over Op,LB: Phase 7 — Resume Signing
 
-    Op->>LB: Drain Node 1
-    Op->>N1: Stop, deploy new image, boot
-    N1->>KMS: Attestation + unseal + rejoin
-    Op->>N1: Verify health
-    Op->>LB: Add Node 1 back
+    Op->>Op: Submit test timestamp request,<br/>validate response with new certificate
+    Op->>LB: Add all nodes to load balancer
+    LB-->>Op: All nodes serving (signing resumed)
 
-    Note over Op,LB: Finalization
+    Note over Op,LB: Phase 8 — Retire Old Certificate
 
-    Op->>Op: Verify all 5 nodes running new version
-    Op->>Op: Verify all 5 nodes healthy
-    Op->>Op: Submit test timestamp, validate response
-    Op->>KMS: Remove old measurement from<br/>attestation policies
-    KMS-->>Op: Only new measurement accepted
-    Op->>Op: Rolling update complete
+    Op->>Op: Publish new certificate to relying parties
+    Op->>CA: Revoke old certificate<br/>(or allow to expire)
+    Op->>Op: Software version change complete
 ```
 
-### 5.2 Update Order Rationale
+### 5.3 Signing Downtime
 
-The update order (Node 5 first, Node 1 last) follows a least-risk-first strategy:
+Unlike a rolling update, a software version change involves a **planned signing outage**. This is an inherent consequence of the immutable software + ephemeral key model: the old key shares are lost when the old software stops, and the new key shares do not exist until DKG completes on the new software.
 
-1. **Node 5 (third provider)**: Updated first because it is the single node on the least-tested provider. If the update causes issues, 4 nodes on the two primary providers remain healthy.
-2. **Nodes 4, 3 (GCP)**: Updated next. After Node 5 succeeds, we have confidence in the new image. Updating GCP nodes leaves the 2 Azure nodes as a stable fallback.
-3. **Nodes 2, 1 (Azure)**: Updated last. By this point, 3 nodes are already running the new image successfully.
-
-### 5.3 Key Safety Rules
-
-- **Never update more than 1 node simultaneously**: This maintains at least 4 nodes online, preserving the ability to tolerate 1 additional unexpected failure while still meeting the threshold of 3.
-- **Accept both measurements during the update window**: The KMS must accept attestation reports with either the old or new measurement while nodes are running mixed versions. Remove the old measurement only after all nodes are updated.
-- **Verify health before proceeding**: After each node update, verify that the node passes health checks (TriHaRd sync, signing test, attestation valid) before moving to the next node.
-- **Rollback plan**: If a node fails to boot or attest with the new image, redeploy the old image to that node. The old measurement is still accepted by the KMS.
-
-### 5.4 Estimated Duration
-
-| Step | Duration | Notes |
+| Phase | Duration | Signing Available |
 |---|---|---|
-| Preparation (build, test, policy update) | 10-30 min | Mostly pre-work |
-| Per-node update cycle | 3-7 min | Drain + stop + deploy + boot + attest + verify |
-| 5 nodes total | 15-35 min | Sequential, one at a time |
-| Finalization | 5 min | Verify all, remove old measurement |
-| **Total** | **30-70 min** | Fully rolling, no signing downtime |
+| Preparation | 10-30 min | Yes (old cluster still serving) |
+| Halt signing + deploy + boot | 5-10 min | **No** |
+| DKG ceremony | 5-12 min | **No** |
+| Certificate issuance | 1-5 min | **No** |
+| Resume signing | <1 min | Yes (new cluster serving) |
+| **Total downtime** | **~12-28 min** | |
+
+**Mitigation strategies for downtime:**
+
+- **Schedule during maintenance windows**: Coordinate with relying parties to minimize impact.
+- **Pre-stage the new image**: Reduce deployment time by pre-uploading images to all providers.
+- **Automate the DKG**: A fully automated DKG ceremony completes in 5-12 minutes with minimal operator interaction.
+- **Use automated CA integration**: ACME-style certificate issuance reduces the certificate phase to under 1 minute.
+
+### 5.4 Key Safety Rules
+
+- **Deploy the same image to all nodes**: All 5 nodes must run identical software to produce the same attestation measurement. Mixed-version clusters are not supported.
+- **No rollback to old key**: Once the old software is stopped, the old key shares are irrecoverably lost. If the new software has issues, the resolution is to fix the new software and run another DKG — not to restore the old key.
+- **Verify before resuming**: Complete the full DKG ceremony and test signing before adding nodes back to the load balancer.
+- **Communicate the certificate change**: Relying parties that pin to specific TSA certificates must be notified of the new certificate. Relying parties that validate via the CA chain are unaffected.
 
 ---
 
@@ -705,79 +696,71 @@ The update order (Node 5 first, Node 1 last) follows a least-risk-first strategy
 - Cloud provider discontinues the VM type or retires the underlying hardware
 - Security incident requiring fresh hardware (e.g., suspected side-channel exposure)
 - Geographic relocation of a node to a different region or provider
-- Scaling from 5 nodes to a larger cluster (future expansion)
 
-### 6.2 Replacement Procedure
+### 6.2 Impact of Node Loss
+
+Under the ephemeral key model, a node failure means the loss of that node's key share. The impact depends on how many nodes remain:
+
+| Nodes Remaining | Impact | Action |
+|---|---|---|
+| 4 of 5 | Signing continues; fault tolerance reduced | Replace node at next convenient DKG |
+| 3 of 5 | Signing continues; zero fault tolerance margin | Schedule DKG promptly to restore 5-node cluster |
+| < 3 of 5 | Signing halted; key effectively lost | Immediate DKG required to resume signing |
+
+A failed node's key share cannot be recovered — it existed only in that node's enclave memory. The replacement procedure always involves a new DKG ceremony that produces new key shares for all nodes.
+
+### 6.3 Replacement Procedure
 
 ```mermaid
 flowchart TD
-    START(["Node Replacement Needed<br/>(e.g., Node 3 failed)"])
+    START(["Node Failed<br/>(e.g., Node 3 offline)"])
 
-    PROVISION["1. Provision new CVM<br/>in same or different provider<br/>(AMD SEV-SNP, SecureTSC)"]
-    DEPLOY["2. Deploy TSA application image<br/>(same version as cluster)"]
-    BOOT["3. Boot new node<br/>Attestation generated automatically"]
-    ATTEST_CHECK{"4. Attestation<br/>verified by KMS?"}
-    HAS_SHARE{"5. Does new node have<br/>a sealed key share?"}
+    CHECK_QUORUM{"Cluster has<br/>>= 3 nodes with<br/>key shares?"}
 
-    UNSEAL["6a. Unseal existing key share<br/>(e.g., cold standby with<br/>share from previous operation)"]
-    REFRESH["6b. Run proactive share refresh<br/>with >= 3 existing nodes + new node<br/>New node receives valid share"]
+    CONTINUE["Signing continues with<br/>remaining nodes<br/>(degraded mode)"]
+    HALTED["Signing halted<br/>(below threshold)"]
 
-    JOIN["7. New node joins cluster<br/>mTLS mesh, TriHaRd sync"]
-    VERIFY["8. Verify: new node passes<br/>health checks, TriHaRd, signing test"]
-    DECOMMISSION["9. Decommission old node<br/>Securely delete old sealed share blob<br/>Power off / destroy VM"]
-    DONE(["Node Replacement Complete<br/>Cluster at full strength"])
+    PROVISION["1. Provision replacement CVM<br/>(AMD SEV-SNP, SecureTSC)"]
+    DEPLOY["2. Deploy same application image<br/>as remaining cluster nodes"]
+    BOOT["3. Boot replacement node"]
+    ATTEST["4. Verify attestation report<br/>(measurement matches cluster)"]
+    ATTEST_CHECK{"Attestation<br/>valid?"}
 
-    FAIL_ATTEST(["Attestation Failed<br/>Check image, measurement,<br/>KMS policy"])
+    DKG["5. Run new DKG ceremony<br/>across all 5 nodes<br/>(new key shares + new certificate)"]
+    VERIFY["6. Verify: test timestamp<br/>request succeeds"]
+    DONE(["Node Replacement Complete<br/>Cluster at full strength<br/>with new key + certificate"])
 
-    START --> PROVISION
+    FAIL_ATTEST(["Attestation Failed<br/>Check image version,<br/>hardware platform"])
+
+    START --> CHECK_QUORUM
+    CHECK_QUORUM -->|"Yes"| CONTINUE
+    CHECK_QUORUM -->|"No"| HALTED
+    CONTINUE --> PROVISION
+    HALTED --> PROVISION
     PROVISION --> DEPLOY
     DEPLOY --> BOOT
-    BOOT --> ATTEST_CHECK
-    ATTEST_CHECK -->|"Yes"| HAS_SHARE
+    BOOT --> ATTEST
+    ATTEST --> ATTEST_CHECK
+    ATTEST_CHECK -->|"Yes"| DKG
     ATTEST_CHECK -->|"No"| FAIL_ATTEST
-    HAS_SHARE -->|"Yes (cold standby)"| UNSEAL
-    HAS_SHARE -->|"No (fresh node)"| REFRESH
-    UNSEAL --> JOIN
-    REFRESH --> JOIN
-    JOIN --> VERIFY
-    VERIFY --> DECOMMISSION
-    DECOMMISSION --> DONE
+    DKG --> VERIFY
+    VERIFY --> DONE
 
     style START fill:#fff3e0,stroke:#ff9800,stroke-width:2px
     style DONE fill:#c8e6c9,stroke:#4caf50,stroke-width:2px
     style FAIL_ATTEST fill:#ffcdd2,stroke:#f44336,stroke-width:2px
+    style CONTINUE fill:#fff9c4,stroke:#fbc02d,stroke-width:2px
+    style HALTED fill:#ffcdd2,stroke:#e53935,stroke-width:2px
 ```
 
-### 6.3 Proactive Share Refresh for New Nodes
+### 6.4 Deferred vs. Immediate Replacement
 
-When a fresh node (one that has never held a key share) joins the cluster, it must receive a valid key share through the proactive share refresh protocol:
+If the cluster still has 3 or more nodes with key shares in memory, signing continues in degraded mode. The operator can choose when to perform the replacement and DKG:
 
-1. The new node boots, attests, and joins the mTLS mesh.
-2. The operator initiates a proactive share refresh with at least 3 existing nodes plus the new node.
-3. During the refresh, new shares are generated for all participants, including the new node.
-4. After the refresh, the old shares (including the old node's share) are invalidated.
-5. The new node seals its share using double-envelope encryption.
+- **Deferred replacement**: Continue signing with the reduced cluster. Provision the replacement node and schedule the DKG during a maintenance window. This minimizes disruption but leaves the cluster with reduced fault tolerance.
+- **Immediate replacement**: Provision the replacement node as quickly as possible and run DKG immediately. This restores full fault tolerance but requires a brief signing outage during the DKG ceremony.
 
-This ensures that the old node's share (which may have been compromised in a security incident) is no longer valid after the refresh. See [Quantum-Safe Threshold Cryptography](03-quantum-safe-threshold-crypto.md) for protocol details.
-
-### 6.4 Cold Standby Activation
-
-Cold standby nodes are pre-provisioned CVMs, powered off, with the same application image as the active cluster. They are designed for rapid recovery.
-
-| Property | Detail |
-|---|---|
-| State when powered off | No key share (shares are NOT pre-distributed to cold standbys) |
-| Image | Same version as active cluster |
-| Location | One cold standby per primary provider (Azure, GCP) |
-| Activation time | 2-5 minutes (boot + attest + unseal or refresh) |
-
-**Activation procedure:**
-
-1. Power on the cold standby VM.
-2. The node boots and generates a fresh attestation report.
-3. **If the standby has a sealed share blob** (from a previous activation where the standby was part of the cluster): the node presents its attestation to the KMS, obtains the wrapping key, and unseals its share. Time to active: 2-3 minutes.
-4. **If the standby has no sealed share blob** (first activation): run proactive share refresh with 3+ existing nodes to provision a share. Time to active: 3-5 minutes.
-5. The standby node joins the cluster, syncs TriHaRd time, and begins serving requests.
+In either case, the DKG ceremony produces entirely new key shares and a new certificate. The old key shares held by the surviving nodes are discarded when they participate in the new DKG.
 
 ---
 
@@ -799,14 +782,15 @@ For a comprehensive analysis of failure modes and their cascading effects, see [
 
 1. Check the failed node's VM status in the provider console (Azure Portal / GCP Console).
 2. Check for provider-level incidents (Azure Status, GCP Status Dashboard).
-3. Attempt automatic restart of the node.
-4. If restart succeeds: verify attestation, key share unseal, TriHaRd sync, and signing participation.
-5. If restart fails: activate cold standby in the same provider (see [Section 6.4](#64-cold-standby-activation)).
-6. If cold standby activation fails: provision a new CVM and run node replacement (see [Section 6.2](#62-replacement-procedure)).
+3. Note: the failed node's key share is lost (it existed only in enclave memory). Signing continues with the remaining 4 nodes.
+4. Assess urgency: signing is operational but fault tolerance is reduced from 2 to 1.
+5. If the node can be restarted on the same hardware: restart, but the node will not have a key share — it will need to participate in a new DKG.
+6. If the node cannot be restarted: provision a replacement CVM (see [Section 6.3](#63-replacement-procedure)).
+7. Schedule a DKG ceremony to restore the cluster to full 5-node strength with new key shares.
 
-**Escalation:** If not recovered within 30 minutes, page on-call engineer.
+**Escalation:** If not recovered within 30 minutes, page on-call engineer. If a second node fails before DKG, escalate to Critical (Playbook 2).
 
-**Resolution criteria:** 5/5 nodes online and passing health checks.
+**Resolution criteria:** New DKG completed with all 5 nodes, new certificate issued, signing verified.
 
 ### Playbook 2: Multiple Node Failure (3/5 Online)
 
@@ -814,20 +798,21 @@ For a comprehensive analysis of failure modes and their cascading effects, see [
 |---|---|
 | **Trigger** | 3/5 nodes online; 2 nodes offline |
 | **Severity** | Critical |
-| **Impact** | Signing continues but with ZERO fault tolerance margin |
+| **Impact** | Signing continues but with ZERO fault tolerance margin; 2 key shares lost |
 
 **Actions:**
 
 1. Page on-call engineer immediately.
 2. Identify root cause: provider outage, network partition, hardware failure, attestation issue.
-3. If provider outage: activate cold standby in the OTHER provider (ensures 4 nodes across 2 providers).
-4. If network partition: check cross-provider mesh, firewall rules, DNS resolution.
-5. Prioritize recovering at least 1 node to restore fault tolerance margin (4/5).
+3. Note: the 2 failed nodes' key shares are irrecoverably lost. Signing continues with 3 remaining nodes but any further failure halts signing.
+4. If network partition: check cross-provider mesh, firewall rules, DNS resolution. Nodes may still be running with key shares intact — restoring connectivity restores the cluster.
+5. If hardware failure: provision replacement nodes as quickly as possible.
 6. If both failed nodes are in the same provider: investigate correlated failure (shared AZ, shared hardware rack).
+7. Once replacement nodes are provisioned, run a new DKG ceremony to restore full 5-node strength.
 
 **Escalation:** If not recovered within 15 minutes, escalate to incident commander.
 
-**Resolution criteria:** At least 4/5 nodes online.
+**Resolution criteria:** New DKG completed with 5 nodes, new certificate issued, signing verified.
 
 ### Playbook 3: Signing Halted (<3 Nodes)
 
@@ -841,16 +826,16 @@ For a comprehensive analysis of failure modes and their cascading effects, see [
 
 1. All-hands page: incident commander, on-call engineers, security team.
 2. Load balancer returns HTTP 503 to all clients.
-3. Execute all-node recovery procedure from [Failure Modes and Recovery](04-failure-modes-and-recovery.md).
-4. For each offline node: attempt restart, if fails activate cold standby, if fails provision new CVM.
-5. As soon as 3 nodes are online: verify signing resumes, test timestamp request.
-6. Continue recovery until at least 4 nodes are online.
+3. All key shares are effectively lost — a new DKG ceremony is required regardless of how many nodes are restored.
+4. For each offline node: attempt restart or provision replacement CVM.
+5. Once all 5 nodes are online and healthy: run a new DKG ceremony to generate new key shares and obtain a new certificate.
+6. Verify signing with the new key by submitting test timestamp requests.
 
-**Communication:** Notify relying parties of outage via status page. Provide ETA for recovery.
+**Communication:** Notify relying parties of outage via status page. Provide ETA for recovery. Note that the TSA certificate will change — relying parties that pin to specific certificates must update.
 
 **Escalation:** Immediate incident commander engagement. If not resolved within 30 minutes, escalate to executive leadership.
 
-**Resolution criteria:** At least 3/5 nodes online and signing resumed. Full resolution: 5/5 nodes online.
+**Resolution criteria:** New DKG completed with 5 nodes, new certificate issued, signing resumed and verified.
 
 ### Playbook 4: Clock Drift Detected
 
@@ -877,21 +862,21 @@ For a comprehensive analysis of failure modes and their cascading effects, see [
 
 | Field | Detail |
 |---|---|
-| **Trigger** | Node's attestation report fails verification, or KMS rejects attestation |
+| **Trigger** | Node's attestation report fails verification during DKG or peer validation |
 | **Severity** | Critical |
-| **Impact** | Node cannot unseal key share; cannot participate in signing |
+| **Impact** | Node cannot participate in DKG or signing; cluster operates without this node |
 
 **Actions:**
 
-1. Verify the expected measurement in the KMS attestation policy matches the deployed application image. Recompute the measurement from the image and compare.
+1. Verify the expected measurement matches the deployed application image. Recompute the measurement from the image and compare.
 2. Check if the AMD-SP firmware was updated by the cloud provider (firmware updates change the platform TCB version, which changes the attestation report).
-3. If the measurement changed due to a provider firmware update: update the KMS attestation policy to accept the new platform TCB version (after verifying the firmware update is legitimate).
-4. If the measurement changed due to an unexpected image modification: **do not update the policy**. Investigate whether the image was tampered with. Treat as a potential security incident.
+3. If the measurement changed due to a provider firmware update: verify the firmware update is legitimate, then redeploy the application image and re-attest. A new DKG will be needed to include this node.
+4. If the measurement changed due to an unexpected image modification: **treat as a potential security incident**. Investigate whether the image was tampered with. Do not include this node in any DKG ceremony.
 5. If the measurement matches but the attestation signature fails verification: check the AMD certificate chain (VCEK -> ASK -> ARK). The VCEK may have been rotated by AMD.
 
 **Escalation:** If attestation failure cannot be explained by a legitimate firmware or VCEK update, escalate to the security team as a potential compromise.
 
-**Resolution criteria:** Attestation succeeds, key share unsealed, node participating in signing.
+**Resolution criteria:** Attestation succeeds, node can participate in DKG and signing.
 
 ### Playbook 6: Suspected Key Compromise
 
@@ -903,24 +888,26 @@ For a comprehensive analysis of failure modes and their cascading effects, see [
 
 **Actions for <3 shares compromised:**
 
-1. Initiate emergency proactive share refresh immediately. This generates new shares for the same key, invalidating the compromised shares.
-2. Ensure the refresh includes all 5 nodes (or at minimum, 3 healthy nodes + any node NOT believed to be compromised).
-3. After refresh: verify all nodes hold new shares, test signing.
-4. Investigate the compromise: how were shares exposed? Enclave breach, KMS compromise, insider threat?
-5. Remediate the root cause before returning to normal operations.
+1. Initiate an emergency DKG ceremony to generate entirely new key shares and a new certificate. This invalidates all existing shares, including the compromised ones.
+2. Halt signing on the current key immediately.
+3. Isolate and investigate the compromised node(s). Do not include suspected-compromised hardware in the new DKG.
+4. Provision replacement nodes if needed to maintain 5-node cluster.
+5. Run DKG on clean nodes, obtain new certificate, resume signing.
+6. Investigate the compromise: how were shares exposed? Enclave breach, side-channel attack, insider threat?
+7. Remediate the root cause before returning to normal operations.
 
 **Actions for >=3 shares compromised:**
 
 1. **Revoke the TSA certificate immediately** (contact CA for emergency revocation).
 2. Signing key must be considered fully compromised.
-3. Initiate a **new DKG ceremony** to generate an entirely new signing key.
+3. Initiate a **new DKG ceremony** on verified-clean hardware to generate an entirely new signing key.
 4. CA issues a new certificate for the new key.
 5. Notify relying parties: timestamps issued before the compromise are still valid (signed with the legitimate key at the time), but the old certificate is revoked.
 6. Conduct a full forensic investigation.
 
 **Escalation:** Immediate engagement of incident commander and security team. If >=3 shares: executive notification, legal review.
 
-**Resolution criteria:** Shares refreshed (or new key generated), compromise contained, root cause identified and remediated.
+**Resolution criteria:** New DKG completed on clean hardware, new certificate issued, compromise contained, root cause identified and remediated.
 
 ### Playbook 7: Certificate Expiry
 
@@ -932,12 +919,12 @@ For a comprehensive analysis of failure modes and their cascading effects, see [
 
 **Actions:**
 
-1. Generate a new CSR from the existing group public key. No DKG is needed -- the signing key is unchanged.
-2. Submit the CSR to the Certificate Authority for renewal.
-3. If CA requires re-verification of the cluster's attestation status: provide current attestation reports from all nodes.
-4. Once the new certificate is issued: distribute it to all 5 nodes.
-5. Verify: submit a test timestamp request and validate the response contains the new certificate with the updated validity period.
-6. Update monitoring to track the new certificate's expiry date.
+1. Because key shares exist only in enclave memory and cannot be exported, certificate renewal requires a new DKG ceremony that produces new key shares and a new public key.
+2. Schedule a DKG ceremony during a maintenance window (see [Section 3](#3-dkg-ceremony-procedure)).
+3. The DKG ceremony includes certificate issuance as an integral step (see [Section 3.5](#35-certificate-issuance-as-part-of-dkg)).
+4. Once the new certificate is issued and signing resumes: verify by submitting a test timestamp request.
+5. Update monitoring to track the new certificate's expiry date.
+6. Revoke or allow the old certificate to expire. Previously issued timestamps remain valid.
 
 **Timeline:**
 
@@ -956,80 +943,72 @@ For a comprehensive analysis of failure modes and their cascading effects, see [
 
 ### 8.1 What Is Backed Up
 
+Under the ephemeral key model, key shares are intentionally not persisted. The backup scope is limited to the artifacts needed to **reconstitute the cluster** (deploy software, run DKG, obtain certificate) — not to restore previous key material.
+
 | Data | Backup Method | Location | Frequency |
 |---|---|---|---|
-| Sealed key share blobs | Geo-redundant storage (provider-native) | Azure Blob Storage (GRS), GCS (multi-region) | After each DKG or share refresh |
-| KMS wrapping keys | KMS built-in geo-replication | Azure Key Vault (geo-replicated), GCP Cloud KMS (multi-region) | Automatic (provider-managed) |
-| TSA certificate + chain | Certificate store on each node + backup storage | All 5 nodes + backup storage (Azure Blob, GCS) | After each issuance or renewal |
+| TSA certificate + chain | Certificate store on each node + backup storage | All 5 nodes + backup storage (cloud storage, offline archive) | After each DKG ceremony |
 | Application image | Container registry or VM image gallery | Each provider's registry (ACR, Artifact Registry) | After each build |
 | DKG ceremony transcript | Encrypted archive | Offline storage (air-gapped or cold storage) | After each DKG ceremony |
 | Configuration (IaC) | Git repository | GitHub / GitLab (with access controls) | After each change (git commit) |
 | Monitoring configuration | Git repository (Grafana dashboards, alert rules) | GitHub / GitLab | After each change |
+| Previous certificates (for verification) | Certificate archive | Offline storage | After each certificate retirement |
 
-### 8.2 What Is NOT Backed Up
+### 8.2 What Is NOT Backed Up (By Design)
 
 | Data | Reason |
 |---|---|
-| Plaintext key shares | Never exist outside enclave memory; backing up would violate the security model |
-| Enclave hardware sealing keys | Derived from the AMD-SP and the specific hardware; not exportable |
+| Key shares | Exist only in enclave memory; ephemeral by design. Backing up would undermine the security model. |
 | Transient signing state | Partial commitments and partial signatures exist only during a signing round |
 
-The sealed key share blobs in backup storage are doubly encrypted (inner: hardware sealing key, outer: KMS wrapping key). They are ciphertext at rest and cannot be decrypted without both the correct hardware platform (inner envelope) and the KMS wrapping key (outer envelope, released only after attestation verification).
+The absence of at-rest key material is a **security feature**, not a limitation. It eliminates the attack surface of sealed blobs, wrapping keys, and KMS attestation policy management. Recovery from any scenario that loses key shares follows the same simple procedure: run a new DKG ceremony.
 
 ### 8.3 Recovery Scenarios
+
+Under the ephemeral model, **key loss is normal operation**. Any scenario that causes nodes to lose their key shares (reboot, failure, planned maintenance) is resolved by a new DKG ceremony. This is a routine procedure, not an emergency.
 
 ```mermaid
 flowchart TD
     INCIDENT(["Incident Occurs"])
 
-    SINGLE["Single Node Failure"]
-    MULTI["Multi-Node Failure<br/>(2 nodes down)"]
+    SINGLE["Single Node Failure<br/>(4 nodes remain)"]
+    MULTI["Multi-Node Failure<br/>(3 nodes remain)"]
     FULL["Full Outage<br/>(all nodes down)"]
     REGION["Provider Region Failure"]
-    KEY_LOSS["Irrecoverable Key Loss<br/>(all shares lost)"]
 
-    SINGLE_R["Recovery: Restart or<br/>activate cold standby<br/>RTO: 2-5 min"]
-    MULTI_R["Recovery: Restart nodes +<br/>activate cold standbys<br/>RTO: 5-15 min"]
-    FULL_R["Recovery: Boot all nodes,<br/>attest to KMS, unseal shares<br/>RTO: 5-15 min"]
-    REGION_R["Recovery: Remaining providers<br/>continue (>= 3 nodes);<br/>activate standby in other provider<br/>RTO: 5-10 min"]
-    KEY_LOSS_R["Recovery: New DKG ceremony +<br/>new certificate from CA<br/>RTO: 15-30 min<br/>RPO: signing key lost"]
+    SINGLE_R["Signing continues (degraded).<br/>Schedule DKG to restore<br/>5-node cluster.<br/>RTO (signing): 0<br/>RTO (full strength): next DKG"]
+    MULTI_R["Signing continues (critical).<br/>Immediate DKG to restore<br/>5-node cluster.<br/>RTO (signing): 0<br/>RTO (full strength): 15-30 min"]
+    FULL_R["Signing halted.<br/>Restore nodes, run DKG,<br/>obtain new certificate.<br/>RTO: 15-30 min"]
+    REGION_R["Remaining providers continue<br/>(>= 3 nodes with key shares).<br/>RTO (signing): 0<br/>Schedule DKG to restore cluster."]
 
-    INCIDENT --> SINGLE & MULTI & FULL & REGION & KEY_LOSS
+    INCIDENT --> SINGLE & MULTI & FULL & REGION
     SINGLE --> SINGLE_R
     MULTI --> MULTI_R
     FULL --> FULL_R
     REGION --> REGION_R
-    KEY_LOSS --> KEY_LOSS_R
 
     style SINGLE fill:#fff9c4,stroke:#fbc02d
     style MULTI fill:#ffcdd2,stroke:#e53935
     style FULL fill:#ffcdd2,stroke:#c62828
     style REGION fill:#ffcdd2,stroke:#e53935
-    style KEY_LOSS fill:#ffcdd2,stroke:#b71c1c
     style SINGLE_R fill:#c8e6c9,stroke:#4caf50
     style MULTI_R fill:#c8e6c9,stroke:#4caf50
-    style FULL_R fill:#c8e6c9,stroke:#4caf50
+    style FULL_R fill:#fff9c4,stroke:#fbc02d
     style REGION_R fill:#c8e6c9,stroke:#4caf50
-    style KEY_LOSS_R fill:#fff9c4,stroke:#fbc02d
 ```
 
 ### 8.4 RTO / RPO Summary
 
-| Scenario | RTO | RPO | Notes |
+| Scenario | RTO (signing) | RTO (full strength) | Notes |
 |---|---|---|---|
-| Single node failure | 2-5 min | 0 (no data loss) | Auto-restart or cold standby activation |
-| Multi-node failure (2 down) | 5-15 min | 0 | Recovery procedure; signing continues if >=3 remain |
-| Full outage (all 5 nodes down) | 5-15 min | 0 | All nodes boot, attest, unseal from KMS + durable storage |
-| Provider region failure | 5-10 min | 0 | Remaining providers continue; activate standby |
-| Irrecoverable key loss (all shares lost) | 15-30 min | Signing key lost | New DKG + new certificate; old timestamps remain valid |
+| Single node failure | 0 (signing continues) | Next scheduled DKG | 4 nodes with key shares; degraded but operational |
+| Multi-node failure (2 down) | 0 (signing continues) | 15-30 min (immediate DKG) | 3 nodes with key shares; critical, zero margin |
+| Full outage (all nodes down) | 15-30 min | 15-30 min | All key shares lost; new DKG + new certificate required |
+| Provider region failure | 0 (signing continues) | Next scheduled DKG | Remaining providers have >= 3 nodes with key shares |
 
-**RPO is 0 for all scenarios except irrecoverable key loss** because:
-- Key shares are persisted as sealed blobs in geo-redundant durable storage.
-- KMS wrapping keys are geo-replicated by the provider.
-- No timestamp data is stored by the TSA (timestamps are returned to clients in real-time).
-- There is no database or state that can be "lost" -- the only persistent state is the sealed key shares and the certificate.
+**Key loss is expected and recoverable**: Every recovery path leads to the same procedure — run a new DKG ceremony. This produces new key shares, a new public key, and a new certificate. Previously issued timestamps remain valid (they were signed with the old key, which was valid at the time of signing, and verifiers can validate against the old certificate).
 
-**Irrecoverable key loss** is the worst-case scenario where all 5 sealed share blobs are lost or corrupted AND the KMS wrapping keys are unavailable. In this case, the signing key cannot be reconstructed. A new DKG ceremony generates a new key, and a new certificate is issued. All previously issued timestamps remain valid (they were signed with the old key, which was valid at the time of signing, and verifiers can validate against the old certificate).
+**No timestamp data is lost in any scenario**: The TSA does not store timestamp data — tokens are returned to clients in real-time. The only state that matters is the ability to sign, which is restored by DKG.
 
 For detailed recovery procedures for each failure scenario, see [Failure Modes and Recovery](04-failure-modes-and-recovery.md).
 
@@ -1037,13 +1016,11 @@ For detailed recovery procedures for each failure scenario, see [Failure Modes a
 
 | Test | Frequency | Procedure |
 |---|---|---|
-| Single node recovery | Monthly | Intentionally stop 1 node, verify auto-recovery or cold standby activation |
-| Cold standby activation | Quarterly | Power on a cold standby, verify it attests and joins cluster |
-| Multi-node recovery | Quarterly | Stop 2 nodes simultaneously, verify signing continues and nodes recover |
-| Full cluster recovery | Semi-annually | Stop all 5 nodes, verify they all boot, attest, unseal, and resume signing |
-| KMS failover | Semi-annually | Simulate KMS unavailability in one provider, verify nodes in other provider continue |
-| DKG ceremony drill | Annually | Run a full DKG ceremony on a staging cluster |
-| Certificate renewal drill | Annually | Renew the certificate on a staging cluster |
+| Single node failure + DKG | Monthly | Intentionally stop 1 node, verify signing continues, run DKG to restore |
+| Multi-node failure | Quarterly | Stop 2 nodes simultaneously, verify signing continues with 3 remaining |
+| Full cluster DKG drill | **Quarterly** | Stop all 5 nodes, boot all, run DKG ceremony, obtain certificate, verify signing |
+| Provider outage simulation | Semi-annually | Disable nodes in one provider, verify remaining providers sustain signing |
+| Certificate issuance drill | Semi-annually | Run DKG on a staging cluster, verify CA issuance and certificate distribution |
 
 ---
 
@@ -1055,13 +1032,13 @@ This section maps the CC-TSA design and operational procedures to the requiremen
 |---|---|---|
 | Timestamping policy | ETSI EN 319 421 Section 6.2 | Defined TSA policy OID, published policy document, policy OID included in every timestamp token |
 | Key generation | ETSI EN 319 421 Section 7.2 | DKG ceremony with mutual attestation, 4-eyes principle (2 operators), ceremony transcript archived |
-| Key protection | ETSI EN 319 421 Section 7.3 | Threshold shares (3-of-5) in SEV-SNP enclaves; double-envelope encryption (hardware sealing + KMS wrapping); shares never plaintext outside enclave memory |
+| Key protection | ETSI EN 319 421 Section 7.3 | Threshold shares (3-of-5) held exclusively in SEV-SNP enclave memory (hardware-encrypted, never persisted to durable storage); software immutability enforced by binding attestation measurement to TSA certificate; no at-rest key material to protect, steal, or manage |
 | Time synchronization | ETSI EN 319 421 Section 7.4 | NTS-authenticated NTP (RFC 8915) with 4+ Stratum-1 sources; SecureTSC hardware clock; TriHaRd Byzantine cross-validation. See [Confidential Computing & Time](02-confidential-computing-and-time.md) |
 | Timestamp accuracy | ETSI EN 319 421 Section 7.4 | 50ms accuracy field in token (actual <2ms); conservative margin for degraded conditions |
 | Audit logging | ETSI EN 319 421 Section 7.5 | Immutable audit log with attestation-bound entries; DKG ceremony transcripts; operational event logging |
-| Disaster recovery | ETSI EN 319 421 Section 7.6 | Multi-provider deployment; KMS-backed recovery; documented procedures (this document); regular DR testing |
+| Disaster recovery | ETSI EN 319 421 Section 7.6 | Multi-provider deployment; recovery via DKG reconstitution (no external key material dependencies); documented procedures (this document); quarterly DKG drill testing |
 | Qualified signatures | eIDAS Article 42 | Hybrid signatures: ECDSA P-384 (qualified today under current standards) + ML-DSA-65 (quantum-safe, future-ready). See [Quantum-Safe Threshold Cryptography](03-quantum-safe-threshold-crypto.md) |
-| WebTrust for CAs | WebTrust Section 4 | Key lifecycle controls (DKG, share refresh, certificate renewal); ceremony procedures with 4-eyes principle; continuous monitoring and alerting |
+| WebTrust for CAs | WebTrust Section 4 | Key lifecycle controls (DKG as routine operation, certificate issuance per DKG); ceremony procedures with 4-eyes principle; continuous monitoring and alerting |
 | RFC 3161 compliance | IETF RFC 3161 | Full compliance with request/response protocol, TSTInfo format, hash algorithm support, nonce handling, policy OID. See [RFC 3161 Compliance](06-rfc3161-compliance.md) |
 | Post-quantum readiness | NIST FIPS 204 | ML-DSA-65 threshold signing provides quantum resistance. Dual signature approach ensures backward compatibility. See [Quantum-Safe Threshold Cryptography](03-quantum-safe-threshold-crypto.md) |
 | Hardware root of trust | Common Criteria (EAL) | AMD SEV-SNP attestation rooted in AMD-SP hardware; VCEK chain verifiable against AMD root certificates. See [Confidential Computing & Time](02-confidential-computing-and-time.md) |
@@ -1073,7 +1050,7 @@ This section maps the CC-TSA design and operational procedures to the requiremen
 | DKG ceremony transcript | Archived after each DKG | Automated: signed log of all ceremony steps, attestation reports, commitments |
 | Attestation reports | Each node, on demand | Automated: periodic attestation report generation and archival |
 | Monitoring records | Prometheus / Grafana | Automated: metric retention (minimum 1 year), alert history |
-| Key share refresh logs | Each share refresh event | Automated: logged with participant attestation reports |
+| DKG ceremony logs | Each DKG ceremony | Automated: logged with participant attestation reports, measurement, certificate |
 | Certificate lifecycle | CA records + node certificates | Manual: CA audit trail + automated node certificate monitoring |
 | Incident response records | Incident management system | Manual: post-incident reports filed after each playbook execution |
 | DR test results | Test execution logs | Manual: test results documented and reviewed quarterly |


### PR DESCRIPTION
## Summary

- **Operations overhaul**: Rewrites 8 sections of `docs/05-operations-and-deployment.md` and 1 section of `docs/02-confidential-computing-and-time.md` to align with the ephemeral key model from Phase 1
- **Eliminates KMS dependency**: Removes all references to Azure Key Vault, GCP Cloud KMS, wrapping keys, double-envelope encryption, and sealed key share blobs
- **DKG as routine operation**: Reframes Distributed Key Generation from a rare one-time ceremony to a routine procedure that runs on every cluster constitution, software change, and certificate renewal
- **Software version changes replace rolling updates**: Replaces the rolling update procedure with a coordinated software version change procedure (halt → deploy → DKG → new certificate → resume)
- **Simplified node replacement**: Failed nodes' key shares are lost by design; replacement always involves a new DKG
- **Updated backup/DR**: Removes at-rest key material from backup scope; reframes key loss as normal operation; increases DKG drill frequency to quarterly
- **Compliance mapping updated**: Justifies ephemeral model to auditors (ETSI, WebTrust)
- **Attestation boot chain updated**: Changes attestation purpose from "gate KMS key release" to "verify node identity during DKG"

## Changes by section

### `docs/05-operations-and-deployment.md` (317 insertions, 340 deletions)

| Section | Change |
|---|---|
| 1.2 Key Management | Replaced KMS/double-envelope with ephemeral key shares in enclave memory |
| 1.3 Networking | Removed Node-to-KMS requirement |
| 2 Deployment Topology | Removed KMS from tables, diagram, and architectural properties |
| 3 DKG Ceremony | Added "When DKG runs" table, removed Phase 8 (sealing), added "Certificate issuance as part of DKG" |
| 4 Day-to-Day Ops | Updated monitoring metrics, rewrote state machine, deleted proactive share refresh |
| 5 → Software Version Change | Complete rewrite from rolling update to coordinated key rotation procedure |
| 6 Node Replacement | Simplified: failed node's share is lost, replacement requires new DKG |
| 7 Incident Playbooks | Updated all 7 playbooks to remove KMS/sealed share/cold standby references |
| 8 Backup & DR | Removed at-rest key material, reframed key loss as normal, quarterly DKG drills |
| 9 Compliance | Updated key protection and DR justifications for ephemeral model |

### `docs/02-confidential-computing-and-time.md`

| Section | Change |
|---|---|
| 7 Attestation Boot Chain | KMS → Peer Nodes in diagram; Steps 5-6 now describe mutual DKG verification |

## Acceptance criteria

- [x] No references to rolling updates, KMS policy updates, or sealed key share recovery remain
- [x] DKG ceremony described as routine operation (every cluster constitution)
- [x] Software version changes described as coordinated key rotation procedures
- [x] Backup/DR documentation reflects intentionally ephemeral key material
- [x] Compliance mapping updated to justify the ephemeral model to auditors
- [x] All operational procedures self-consistent with the Phase 1 core model

## Test plan

- [ ] Review all Mermaid diagrams render correctly
- [ ] Verify no broken cross-references between documents
- [ ] Confirm no stale references to KMS, sealed blobs, rolling updates, or proactive share refresh remain in active context

🤖 Generated with [Claude Code](https://claude.com/claude-code)