### PR TITLE
Fix CI pipeline failures: libasound2 rename and hashFiles on workflow_dispatch

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Core Chromium dependencies
     libglib2.0-0 libnss3 libnspr4 libdbus-1-3 libatk1.0-0 \
     libatk-bridge2.0-0 libcups2 libdrm2 libxkbcommon0 libatspi2.0-0 \
-    libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libasound2 \
+    libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libasound2t64 \
     # Fonts
     fonts-liberation fonts-noto-color-emoji \
     # Playwright host dependencies (recommended)

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -21,11 +21,36 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  check-files:
+    name: Check Repository Files
+    runs-on: ubuntu-latest
+    outputs:
+      has_cargo_toml: ${{ steps.check.outputs.has_cargo_toml }}
+      has_dockerfile: ${{ steps.check.outputs.has_dockerfile }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for key files
+        id: check
+        run: |
+          if [ -f Cargo.toml ]; then
+            echo "has_cargo_toml=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_cargo_toml=false" >> $GITHUB_OUTPUT
+          fi
+          if [ -f Dockerfile ]; then
+            echo "has_dockerfile=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_dockerfile=false" >> $GITHUB_OUTPUT
+          fi
+
   test:
     name: Run Rust Tests
     runs-on: ubuntu-latest
+    needs: check-files
     # Only run if there's actual Rust code to test
-    if: hashFiles('Cargo.toml') != ''
+    if: needs.check-files.outputs.has_cargo_toml == 'true'
 
     steps:
       - name: Checkout code
@@ -53,9 +78,9 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
-    needs: test
+    needs: [check-files, test]
     # Only run if an application Dockerfile exists
-    if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped') && hashFiles('Dockerfile') != ''
+    if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped') && needs.check-files.outputs.has_dockerfile == 'true'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -40,9 +40,19 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       code: ${{ steps.filter.outputs.code }}
       docker: ${{ steps.filter.outputs.docker }}
+      has_cargo_toml: ${{ steps.check-files.outputs.has_cargo_toml }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Check for key files
+        id: check-files
+        run: |
+          if [ -f Cargo.toml ]; then
+            echo "has_cargo_toml=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_cargo_toml=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Check for changes
         uses: dorny/paths-filter@v3
@@ -94,7 +104,7 @@ jobs:
   unit-tests:
     name: Unit Tests (Required for PR Merge)
     needs: changes
-    if: needs.changes.outputs.code == 'true' && hashFiles('Cargo.toml') != ''
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.has_cargo_toml == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -126,7 +136,7 @@ jobs:
   integration-tests:
     name: Integration Tests (Required for PR Merge)
     needs: changes
-    if: needs.changes.outputs.code == 'true' && hashFiles('Cargo.toml') != ''
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.has_cargo_toml == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

- **Devcontainer fix:** Update `libasound2` to `libasound2t64` in `.devcontainer/Dockerfile` — the package was renamed in Ubuntu 24.04's 64-bit time_t transition, breaking devcontainer builds and all review workflows
- **Workflow fix:** Replace job-level `hashFiles()` calls with explicit file-existence checks in `pr-tests.yml` and `docker-build-push.yml` — `hashFiles()` fails on `workflow_dispatch` because no workspace exists at job-level `if:` evaluation time, making these workflows un-re-runnable manually

## Test plan

- [ ] Verify devcontainer builds successfully (libasound2t64 resolves on Ubuntu 24.04)
- [ ] Re-run `PR Tests` via `workflow_dispatch` — should skip Rust jobs gracefully (no Cargo.toml yet)
- [ ] Re-run `Build and Push Docker Image` via `workflow_dispatch` — should skip gracefully (no Cargo.toml/Dockerfile yet)
- [ ] Verify push-triggered runs on main still work correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)