### PR TITLE
Fix #8: Add AMD hardware dependency and vulnerability exploitability analysis to threat model

### DIFF
--- a/docs/02-confidential-computing-and-time.md
+++ b/docs/02-confidential-computing-and-time.md
@@ -136,7 +136,7 @@ Importantly, this research does **not** demonstrate any ability to manipulate Se
 — the paper's authors explicitly confirm that SecureTSC is resilient to modification attempts
 and remains a trustworthy time source.
 The co-location detection is a privacy/metadata leakage concern, not a time integrity concern.
-The proposed mitigation (hypervisors using randomized `DESIRED_TSC_FREQUENCY` values per guest)
+The proposed mitigation (hypervisors using randomized `DESIRED_TSC_FREQ` values per guest)
 can be deployed at the cloud provider level without changes to AMD silicon.
 
 For CC-TSA, the co-location risk is addressed by the multi-provider deployment model:

--- a/docs/07-threat-model.md
+++ b/docs/07-threat-model.md
@@ -438,7 +438,7 @@ and AMD's track record of responsive patching.
 | CacheWarp | 2023 | CVE-2023-20592 | Medium (5.3) | Yes | Fault injection (cache) | Patched (microcode) |
 | Firmware vulns | 2024 | — | Medium | Yes | Firmware logic errors | Patched (AMD-SB-3007) |
 | RMP init race | 2024 | — | High | Yes | Race condition in RMP | Patched (AMD-SB-3020) |
-| TsCupid | 2024 | — | Low | Yes (SecureTSC) | Co-location detection | Disclosed; mitigation proposed |
+| TsCupid | 2025 | — | Low | Yes (SecureTSC) | Co-location detection | Disclosed; mitigation proposed |
 | Microcode bypass | 2025 | CVE-2024-56161 | High (7.2) | Yes | Hash flaw in verification | Patched (microcode) |
 | CounterSEVeillance | 2025 | — | Medium | Yes | Perf counter side-channel | Ongoing research |
 | Heracles | 2025 | — | Medium | Yes | Chosen plaintext attack | Mitigated on Zen 5 |
@@ -478,7 +478,7 @@ not an attack in itself. For CC-TSA, the implications are:
    in a more complex attack (e.g., a cache side-channel attack against the enclave).
    The subsequent steps face the full set of SEV-SNP protections.
 3. **Mitigation**: The paper proposes that hypervisors use randomly generated
-   `DESIRED_TSC_FREQUENCY` values per guest,
+   `DESIRED_TSC_FREQ` values per guest,
    which would eliminate the co-location signal.
    This is a hypervisor-level change that cloud providers can deploy
    independently of AMD silicon changes.


### PR DESCRIPTION
Resolves #8

## Summary

- Added new **Section 9: AMD Hardware Dependency Analysis** to `docs/07-threat-model.md` covering:
  - Vendor dependency concern framing and comparison to other hardware-rooted trust systems
  - Comprehensive table of 10 known AMD SEV vulnerabilities (2021-2026) with severity, SNP applicability, and patch status
  - Detailed analysis of the "Not So Secure TSC" paper (TsCupid co-location detection) — what it does and does not demonstrate
  - Exploitability analysis with four practical barriers: workload identification, threshold requirement, cloud provider collusion complexity, and vulnerability severity context
  - Vendor lock-in mitigation strategy (short/medium/long-term) including Intel TDX mixed-hardware clusters and ARM CCA roadmap
  - Systemic risk assessment table
- Updated `docs/02-confidential-computing-and-time.md` SecureTSC section with:
  - Security research context about the TsCupid co-location finding
  - Cross-reference to the new threat model analysis section

The analysis concludes that while AMD hardware dependency is a legitimate concern, CC-TSA's multi-provider threshold architecture converts it from a single point of failure into a coordinated multi-point attack requiring exploitation across multiple independent cloud providers — making known AMD SEV vulnerabilities unrealistic attack vectors against a correctly deployed cluster.

## Test Plan
- [x] `markdownlint '**/*.md' --config .markdownlint.json` passes with no errors
- [ ] Review Section 9 of `docs/07-threat-model.md` for technical accuracy
- [ ] Review SecureTSC security research additions in `docs/02-confidential-computing-and-time.md`
- [ ] Verify vulnerability table entries against AMD security bulletins
- [ ] Confirm the exploitability analysis aligns with the project's threat model assumptions

Generated with Claude Code