### PR TITLE
Document multi-provider design rationale and client ecosystem constraints

### DIFF
--- a/docs/01-architecture-overview.md
+++ b/docs/01-architecture-overview.md
@@ -675,6 +675,7 @@ rather than from distributing a single TSA's nodes across providers.
 - Lower signing latency: intra-provider round-trips for threshold signing are consistently low.
 - Independent failure domains: each TSA cluster can be operated, upgraded, and recovered independently.
 - Simpler per-TSA operations: DKG ceremonies, monitoring, and incident response are scoped to a single provider.
+- Independent certificate chains: each single-provider TSA could have its own certificate chain, which some compliance frameworks might prefer for organizational or jurisdictional separation.
 
 **Why it was rejected:**
 
@@ -711,13 +712,27 @@ Every consumer of timestamps would need custom logic to:
 (c) reason about cross-provider coverage when verifying.
 This is a non-standard workflow that no existing verification tool supports.
 
+5. **A TSA aggregation proxy does not resolve the fundamental issue.**
+One might consider a gateway that internally fans out to multiple single-provider TSAs
+and returns one token to the client.
+However, such a proxy would need to either (a) select one provider's token to return —
+losing multi-provider assurance in the token itself — or (b) bundle multiple tokens,
+which still requires clients to understand and verify the bundle format.
+RFC 3161 defines one `TimeStampResp` per `TimeStampReq`;
+there is no standard envelope for a multi-TSA token bundle.
+The cross-provider threshold approach avoids this problem entirely
+because the single token is genuinely co-signed by nodes across providers.
+
 **Conclusion:** The cross-provider threshold design gives every standard RFC 3161 client
 multi-provider assurance in a single token with zero client-side changes.
 A client points at one TSA URL, receives one token,
 and that token inherently carries the guarantee
 that nodes across multiple cloud providers participated in its creation.
-This is strictly more practical than any alternative
+This is strictly more practical than the multi-TSA alternative
 requiring client-side multi-TSA coordination.
+
+See also [RFC 3161 Compliance — Client Ecosystem Constraints](06-rfc3161-compliance.md#7-client-ecosystem-constraints)
+for how standard RFC 3161 clients and PDF signing tools reinforce this design choice.
 
 ---
 

--- a/docs/06-rfc3161-compliance.md
+++ b/docs/06-rfc3161-compliance.md
@@ -28,9 +28,10 @@ see [Confidential Computing & Time](02-confidential-computing-and-time.md).
 4. [CMS SignedData Structure](#4-cms-signeddata-structure)
 5. [Verification Decision Tree](#5-verification-decision-tree)
 6. [Backward Compatibility](#6-backward-compatibility)
-7. [Accuracy Field](#7-accuracy-field)
-8. [Token Size Analysis](#8-token-size-analysis)
-9. [HTTP Transport](#9-http-transport)
+7. [Client Ecosystem Constraints](#7-client-ecosystem-constraints)
+8. [Accuracy Field](#8-accuracy-field)
+9. [Token Size Analysis](#9-token-size-analysis)
+10. [HTTP Transport](#10-http-transport)
 
 ---
 
@@ -273,7 +274,7 @@ TSTInfo ::= SEQUENCE {
 | `messageImprint` | Copied from request | Hash algorithm OID + hash value, unchanged |
 | `serialNumber` | Monotonically increasing, unique | Per-node counter + node ID to ensure global uniqueness across the cluster |
 | `genTime` | UTC from SecureTSC + NTS | GeneralizedTime with fractional seconds (e.g., `20260213120000.000Z`) |
-| `accuracy` | `{seconds: 1, millis: 0, micros: 0}` | 1 second conservative; timestamping is not latency-sensitive work (see [Section 7](#7-accuracy-field)) |
+| `accuracy` | `{seconds: 1, millis: 0, micros: 0}` | 1 second conservative; timestamping is not latency-sensitive work (see [Section 8](#8-accuracy-field)) |
 | `ordering` | FALSE | CC-TSA does not guarantee total ordering across all tokens |
 | `nonce` | Copied from request (if present) | Echoed for replay protection; absent if not in request |
 | `tsa` | CC-TSA GeneralName | DirectoryName with the TSA's distinguished name from the certificate |
@@ -661,7 +662,7 @@ CC-TSA tokens are verified by these libraries without any patches or configurati
 
 5. **Token is slightly larger**: The ML-DSA-65 signature (~3.3 KB) and ML-DSA certificate (~3.5 KB) add approximately 6.8 KB to the token.
 This does not affect ASN.1 parsing or CMS processing -- it simply means more bytes are read and skipped.
-See [Section 8](#8-token-size-analysis) for a detailed size breakdown.
+See [Section 9](#9-token-size-analysis) for a detailed size breakdown.
 
 ### PQC-Aware Verifiers
 
@@ -725,15 +726,25 @@ However, the ML-DSA-65 signature -- already present in every token issued since 
 and provides continued assurance that the timestamp was issued by the CC-TSA at the stated time.
 No retroactive action is needed for the CC-TSA's timestamps to remain verifiable in a post-quantum world.
 
+---
+
+## 7. Client Ecosystem Constraints
+
+Standard RFC 3161 clients and PDF signing tools are designed around a single TSA endpoint,
+which has direct implications for multi-provider assurance strategies.
+
 ### Single-Token Multi-Provider Assurance
 
-Standard RFC 3161 clients and PDF signing tools are designed around a single TSA endpoint.
 The RFC 3161 protocol is single-request/single-response:
 a client sends one `TimeStampReq` to one TSA URL and receives one `TimeStampResp`.
-PDF signing libraries (PAdES, Adobe Acrobat, iText, PDFBox)
+No standard client implementation queries multiple TSAs for the same data
+or bundles multiple tokens together.
+PDF signing libraries (PAdES, Adobe Acrobat, iText, PDFBox, Adobe SDK)
 configure a single TSA URL per document signature.
-No standard client queries multiple TSAs
-or bundles multiple tokens for provider-diversity purposes.
+While the PDF specification supports multiple document timestamps,
+this mechanism is designed for temporal layering
+(adding timestamps over time for long-term archival validation under PAdES-LTV),
+not for concurrent multi-provider coverage.
 
 The CC-TSA cross-provider threshold design takes advantage of this reality:
 because the 3-of-5 threshold signing cluster is distributed
@@ -743,15 +754,13 @@ without requiring any client-side changes.
 A standard RFC 3161 client points at the CC-TSA endpoint, receives a single token,
 and that token is guaranteed to have been co-signed by nodes spanning multiple providers.
 
-This is a key practical advantage over alternative architectures
-(such as deploying independent single-provider TSAs)
-that would require clients to interact with multiple TSAs
-and implement custom logic to collect, store, and reason about multiple tokens per artifact —
-a workflow no existing RFC 3161 client or PDF signing tool supports.
+For the full design rationale — including the rejected multi-TSA alternative,
+the TSA aggregation proxy consideration, and why the cross-provider threshold approach
+was chosen — see [Architecture Overview — Alternative Considered: Multiple Independent Single-Provider TSAs](01-architecture-overview.md#64-alternative-considered-multiple-independent-single-provider-tsas).
 
 ---
 
-## 7. Accuracy Field
+## 8. Accuracy Field
 
 ### RFC 3161 Accuracy Definition
 
@@ -837,7 +846,7 @@ The 1-second accuracy field provides approximately a 10x safety margin over the 
 
 ---
 
-## 8. Token Size Analysis
+## 9. Token Size Analysis
 
 ### Component Breakdown
 
@@ -904,7 +913,7 @@ This reduces the total to approximately **5.1 KB** with both certificates omitte
 
 ---
 
-## 9. HTTP Transport
+## 10. HTTP Transport
 
 CC-TSA implements the HTTP transport protocol defined in RFC 3161 Section 3.4, with additional security requirements and operational endpoints.
 


### PR DESCRIPTION
## Summary

- Adds Section 6.4 to the architecture overview documenting the rejected alternative of deploying multiple independent single-provider TSAs instead of one cross-provider threshold cluster
- Adds a "Single-Token Multi-Provider Assurance" subsection to the RFC 3161 compliance doc noting that standard clients and PDF signing tools assume a single TSA endpoint
- Key insight: RFC 3161 is single-request/single-response, and PDF signing libraries (PAdES, Adobe Acrobat, iText, PDFBox) configure one TSA URL per signature — making the cross-provider threshold approach strictly more practical since it gives every client multi-provider assurance in a single token with zero client-side changes

## Test plan

- [ ] Verify markdownlint passes (lines kept under 200-char limit, no duplicate sibling headings)
- [ ] Verify new sections integrate cleanly with surrounding content in both docs
- [ ] Confirm cross-references between the two documents are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)