### PR TITLE
Switch CVM deployment region to westus

### DIFF
--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,7 +1,7 @@
 variable "location" {
   description = "Azure region — must support DCasv5 series"
   type        = string
-  default     = "eastus"
+  default     = "westus"
 }
 
 variable "resource_prefix" {


### PR DESCRIPTION
## Summary
- Switch default Azure region from `eastus` to `westus` in `infra/variables.tf`
- The subscription has 0 DCASv5 vCPU quota in eastus and self-service increases are blocked for this confidential computing SKU family
- Quota was approved for westus (4 vCPUs), unblocking the CI deploy pipeline

## Context
Pipeline run [#22082549221](https://github.com/NickBorgers/confidential-computing-tsa/actions/runs/22082549221) failed at Terraform Apply with:
```
OperationNotAllowed: Operation could not be completed as it results in exceeding
approved standardDCASv5Family Cores quota. Current Limit: 0
```

## Test plan
- [ ] Merge and verify the `Deploy Confidential VM` workflow succeeds with westus region

🤖 Generated with [Claude Code](https://claude.com/claude-code)