### PR TITLE
Update docs to reflect PoC implementation status

### DIFF
--- a/docs/01-architecture-overview.md
+++ b/docs/01-architecture-overview.md
@@ -8,6 +8,11 @@ It covers design goals, components, trust boundaries, platform selection, the ti
 
 For deeper treatment of specific topics, see the companion documents referenced throughout.
 
+> **Implementation status**: The two-layer architecture (Section 2.6) is implemented as a working PoC —
+> the CVM core and wrapper are deployed to an Azure SEV-SNP confidential VM with end-to-end RFC 3161
+> validation in CI. The current implementation uses single-signer ECDSA P-384; the 5-node cluster,
+> threshold signing, and multi-cloud deployment described in this document are design targets not yet built.
+
 ---
 
 ## Table of Contents

--- a/docs/02-confidential-computing-and-time.md
+++ b/docs/02-confidential-computing-and-time.md
@@ -9,6 +9,12 @@ For the overall system architecture and component interactions, see [Architectur
 For how the signing key is generated and used within these enclaves,
 see [Quantum-Safe Threshold Cryptography](03-quantum-safe-threshold-crypto.md).
 
+> **Implementation status**: The PoC runs on an Azure AMD SEV-SNP confidential VM with hardware
+> attestation verified in CI (vTPM, memory encryption, VCEK certificate retrieval). The CVM core
+> includes SecureTSC reading and monotonic enforcement stubs. NTS authentication, TriHaRd cross-node
+> time validation, and the full four-layer time trust chain described here are design targets
+> not yet implemented.
+
 ---
 
 ## 1. AMD SEV-SNP Deep Dive

--- a/docs/03-quantum-safe-threshold-crypto.md
+++ b/docs/03-quantum-safe-threshold-crypto.md
@@ -5,6 +5,10 @@ used by the Confidential Computing Timestamp Authority (CC-TSA). For system arch
 see [Architecture Overview](01-architecture-overview.md). For the hardware-attested execution environment that protects key shares at runtime,
 see [Confidential Computing and Time](02-confidential-computing-and-time.md).
 
+> **Implementation status**: The PoC implements single-signer ECDSA P-384 signing inside the CVM core.
+> The threshold ML-DSA-65 protocol, DKG ceremony, hybrid dual-signature tokens, and key lifecycle
+> management described in this document are design targets not yet implemented.
+
 ---
 
 ## Table of Contents

--- a/docs/04-failure-modes-and-recovery.md
+++ b/docs/04-failure-modes-and-recovery.md
@@ -9,6 +9,10 @@
 > - [Operations and Deployment](05-operations-and-deployment.md) — deployment procedures, monitoring, alerting
 > - [Threat Model](07-threat-model.md) — adversarial scenarios and mitigations
 
+**Implementation status**: This document describes failure modes for the full production 5-node
+cluster. The current PoC runs a single Azure CVM; multi-node failure scenarios, quorum loss
+recovery, and the cluster health state machine are design targets not yet applicable.
+
 This document defines every failure scenario the CC-TSA system can encounter, the impact of each, and the exact recovery procedures to follow.
 The CC-TSA uses a **3-of-5 threshold signing** configuration: 5 AMD SEV-SNP enclave nodes each hold one key share,
 and a minimum of 3 nodes must be online to produce a valid timestamp signature. Key shares are **ephemeral** —

--- a/docs/05-operations-and-deployment.md
+++ b/docs/05-operations-and-deployment.md
@@ -10,6 +10,11 @@ For the overall system architecture, see [Architecture Overview](01-architecture
 For failure scenarios and recovery procedures, see [Failure Modes and Recovery](04-failure-modes-and-recovery.md).
 For the threshold cryptography underpinning key management, see [Quantum-Safe Threshold Cryptography](03-quantum-safe-threshold-crypto.md).
 
+> **Implementation status**: The PoC deployment uses Terraform IaC (`infra/`) to provision a single
+> Azure SEV-SNP confidential VM, with SCP-based binary deployment and CI validation
+> (see `.github/workflows/azure-deploy.yml`). The multi-node cluster operations, DKG ceremony
+> procedures, and production runbooks described here are design targets for future implementation.
+
 ---
 
 ## Table of Contents

--- a/docs/06-rfc3161-compliance.md
+++ b/docs/06-rfc3161-compliance.md
@@ -2,6 +2,12 @@
 
 > **CC-TSA Design Document 06** | Audience: Architects, Engineers, Security Reviewers, Integrators
 
+**Implementation status**: The PoC implements RFC 3161 request parsing, TSTInfo construction,
+CMS SignedData assembly, and TimeStampResp serialization — validated end-to-end in CI against a
+real Azure SEV-SNP deployment. The current implementation produces a single ECDSA P-384
+`SignerInfo`. The dual-signature hybrid tokens (ECDSA + ML-DSA-65) described below are a design
+target not yet implemented.
+
 This document provides a detailed analysis of how the Confidential Computing Timestamp Authority (CC-TSA) implements the RFC 3161 Time-Stamp Protocol.
 It covers request processing, response structure, the CMS SignedData encoding with dual hybrid signatures (ECDSA P-384 + ML-DSA-65),
 backward compatibility with classical verifiers, the verification decision tree, accuracy semantics, token size analysis, and HTTP transport.

--- a/docs/07-threat-model.md
+++ b/docs/07-threat-model.md
@@ -7,6 +7,10 @@ For system architecture and component descriptions, see [Architecture Overview](
 For cryptographic details, see [Quantum-Safe Threshold Crypto](03-quantum-safe-threshold-crypto.md).
 For failure recovery, see [Failure Modes & Recovery](04-failure-modes-and-recovery.md).
 
+> **Implementation status**: The threat model covers the full production system. The PoC validates
+> the CVM/wrapper trust boundary and AMD SEV-SNP attestation. Mitigations that depend on threshold
+> signing, multi-cloud distribution, or NTS time validation are design targets not yet active.
+
 ---
 
 ## 1. Adversary Model

--- a/docs/08-throughput-and-scaling.md
+++ b/docs/08-throughput-and-scaling.md
@@ -8,6 +8,10 @@ and presents a scaling strategy with cost estimates for reaching higher volumes.
 For the system architecture underpinning this analysis, see [Architecture Overview](01-architecture-overview.md).
 For the threshold signing protocol that determines per-request latency, see [Quantum-Safe Threshold Cryptography](03-quantum-safe-threshold-crypto.md).
 
+> **Implementation status**: This analysis is based on projected performance of the full 5-node
+> threshold signing cluster. The PoC runs a single-signer node; throughput benchmarking against
+> these projections has not yet been performed.
+
 ---
 
 ## Table of Contents

--- a/docs/09-enclave-interface.md
+++ b/docs/09-enclave-interface.md
@@ -13,6 +13,12 @@ attestation measurement bound to the TSA certificate.
 
 For the overall system architecture and the rationale for the two-layer split,
 see [Architecture Overview](01-architecture-overview.md), Section 2.6.
+
+> **Implementation status**: This interface is implemented and tested. The CVM core and wrapper are
+> deployed to an Azure SEV-SNP VM with the binary vsock protocol, TSTInfo encoder, signedAttrs
+> construction, and ECDSA P-384 signing all validated end-to-end in CI (67 tests). The CVM state
+> machine runs in TCP mode for the PoC; vsock transport is a deployment-time switch.
+
 For RFC 3161 protocol details, see [RFC 3161 Compliance](06-rfc3161-compliance.md).
 For the threat model analysis of the wrapper, see [Threat Model](07-threat-model.md), Scenario 7.
 


### PR DESCRIPTION
## Summary

- **README**: Add project status table showing implemented vs. designed components, code structure overview with annotated directory tree, build/test/Docker instructions, devcontainer reference, and complete the document map (add missing docs 08 and 09)
- **Design docs 01-09**: Add implementation status annotations near the top of each document, distinguishing what the PoC has built from what remains a design target

The design docs were written as forward-looking architecture specifications before the PoC existed. Now that we have a working TSA deployed to an Azure SEV-SNP VM with end-to-end CI validation (PRs #17, #21, #30), a reader needs to understand what's real vs. planned.

## Test plan

- [ ] Verify README renders correctly on GitHub (status table, code structure tree, build commands)
- [ ] Verify blockquote annotations render correctly in each design doc
- [ ] Confirm document map links for docs 08 and 09 resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)