### PR TITLE
Prevent GitHub Actions comment feedback loop

### DIFF
--- a/.github/scripts/setup-gh-wrapper.sh
+++ b/.github/scripts/setup-gh-wrapper.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Programmatic bot marker injection: wrap gh so all comments
+# automatically get the <!-- bot:claude-workflow --> marker appended.
+# This prevents feedback loops where Claude-authored comments
+# could re-trigger the Claude workflow.
+#
+# Usage: source this script before invoking Claude in any workflow.
+# It replaces `gh` on PATH with a wrapper that intercepts
+# `gh pr comment` and `gh issue comment` to append the marker.
+
+REAL_GH="$(which gh)"
+cat > /tmp/gh-wrapper << 'GHWRAPPER'
+#!/bin/bash
+MARKER=$'\n<!-- bot:claude-workflow -->'
+# Intercept 'gh pr comment' and 'gh issue comment' to append marker
+if { [ "${1:-}" = "pr" ] && [ "${2:-}" = "comment" ]; } || \
+   { [ "${1:-}" = "issue" ] && [ "${2:-}" = "comment" ]; }; then
+  args=()
+  i=1
+  while [ $i -le $# ]; do
+    arg="${!i}"
+    args+=("$arg")
+    if [ "$arg" = "--body" ]; then
+      i=$((i + 1))
+      val="${!i}"
+      # Append marker if not already present
+      if ! echo "$val" | grep -qF '<!-- bot:claude-workflow -->'; then
+        val="${val}${MARKER}"
+      fi
+      args+=("$val")
+    fi
+    i=$((i + 1))
+  done
+  exec "__REAL_GH__" "${args[@]}"
+else
+  exec "__REAL_GH__" "$@"
+fi
+GHWRAPPER
+sed -i "s|__REAL_GH__|${REAL_GH}|g" /tmp/gh-wrapper
+chmod +x /tmp/gh-wrapper
+export PATH="/tmp:$PATH"
+ln -sf /tmp/gh-wrapper /tmp/gh

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -387,6 +387,9 @@ jobs:
             PR_BODY=$(echo "$PR_BODY_B64" | base64 -d 2>/dev/null || echo "")
             ISSUE_BODY=$(echo "$ISSUE_BODY_B64" | base64 -d 2>/dev/null || echo "")
 
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             claude --print \
               --verbose \
               --output-format stream-json \
@@ -800,6 +803,9 @@ jobs:
             STANDARDS_REVIEW_RESULT=${{ needs.standards-review.result }}
             RFC_STANDARDS_REVIEW_RESULT=${{ needs.rfc-standards-review.result }}
           runCmd: |
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             claude --print \
               --verbose \
               --output-format stream-json \

--- a/.github/workflows/claude-diagnose-workflow-failure.yml
+++ b/.github/workflows/claude-diagnose-workflow-failure.yml
@@ -179,6 +179,9 @@ jobs:
             HEAD_SHA=${{ needs.check-failure.outputs.head_sha }}
             REPO=${{ github.repository }}
           runCmd: |
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             # Run Claude to diagnose the workflow failure
             # Using Sonnet: Classification task with clear decision tree (3 categories)
             claude --print \

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -218,38 +218,7 @@ jobs:
 
             # Programmatic bot marker injection: wrap gh so all comments
             # automatically get the marker appended, regardless of LLM compliance.
-            REAL_GH="$(which gh)"
-            cat > /tmp/gh-wrapper << 'GHWRAPPER'
-            #!/bin/bash
-            MARKER=$'\n<!-- bot:claude-workflow -->'
-            # Intercept 'gh pr comment' and 'gh issue comment' to append marker
-            if { [ "${1:-}" = "pr" ] && [ "${2:-}" = "comment" ]; } || \
-               { [ "${1:-}" = "issue" ] && [ "${2:-}" = "comment" ]; }; then
-              args=()
-              i=1
-              while [ $i -le $# ]; do
-                arg="${!i}"
-                args+=("$arg")
-                if [ "$arg" = "--body" ]; then
-                  i=$((i + 1))
-                  val="${!i}"
-                  # Append marker if not already present
-                  if ! echo "$val" | grep -qF '<!-- bot:claude-workflow -->'; then
-                    val="${val}${MARKER}"
-                  fi
-                  args+=("$val")
-                fi
-                i=$((i + 1))
-              done
-              exec "__REAL_GH__" "${args[@]}"
-            else
-              exec "__REAL_GH__" "$@"
-            fi
-            GHWRAPPER
-            sed -i "s|__REAL_GH__|${REAL_GH}|g" /tmp/gh-wrapper
-            chmod +x /tmp/gh-wrapper
-            export PATH="/tmp:$PATH"
-            ln -sf /tmp/gh-wrapper /tmp/gh
+            source .github/scripts/setup-gh-wrapper.sh
 
             # Build the prompt based on whether this is a PR or issue comment
             if [ "$IS_PR" = "true" ]; then
@@ -394,38 +363,7 @@ jobs:
 
             # Programmatic bot marker injection: wrap gh so all comments
             # automatically get the marker appended, regardless of LLM compliance.
-            REAL_GH="$(which gh)"
-            cat > /tmp/gh-wrapper << 'GHWRAPPER'
-            #!/bin/bash
-            MARKER=$'\n<!-- bot:claude-workflow -->'
-            # Intercept 'gh pr comment' and 'gh issue comment' to append marker
-            if { [ "${1:-}" = "pr" ] && [ "${2:-}" = "comment" ]; } || \
-               { [ "${1:-}" = "issue" ] && [ "${2:-}" = "comment" ]; }; then
-              args=()
-              i=1
-              while [ $i -le $# ]; do
-                arg="${!i}"
-                args+=("$arg")
-                if [ "$arg" = "--body" ]; then
-                  i=$((i + 1))
-                  val="${!i}"
-                  # Append marker if not already present
-                  if ! echo "$val" | grep -qF '<!-- bot:claude-workflow -->'; then
-                    val="${val}${MARKER}"
-                  fi
-                  args+=("$val")
-                fi
-                i=$((i + 1))
-              done
-              exec "__REAL_GH__" "${args[@]}"
-            else
-              exec "__REAL_GH__" "$@"
-            fi
-            GHWRAPPER
-            sed -i "s|__REAL_GH__|${REAL_GH}|g" /tmp/gh-wrapper
-            chmod +x /tmp/gh-wrapper
-            export PATH="/tmp:$PATH"
-            ln -sf /tmp/gh-wrapper /tmp/gh
+            source .github/scripts/setup-gh-wrapper.sh
 
             # Fetch issue body via API to avoid multi-line env var escaping issues
             ISSUE_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.body')

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -108,9 +108,9 @@ jobs:
     needs: [authorize, build-devcontainer]
     if: |
       needs.authorize.outputs.authorized == 'true' &&
-      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '<!-- bot:')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '<!-- bot:')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '<!-- bot:')) ||
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '<!-- bot:') && github.event.comment.user.type != 'Bot') ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '<!-- bot:') && github.event.comment.user.type != 'Bot') ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '<!-- bot:') && github.event.review.user.type != 'Bot') ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -108,9 +108,9 @@ jobs:
     needs: [authorize, build-devcontainer]
     if: |
       needs.authorize.outputs.authorized == 'true' &&
-      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '<!-- bot:claude-workflow -->')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '<!-- bot:claude-workflow -->')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '<!-- bot:claude-workflow -->')) ||
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '<!-- bot:')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '<!-- bot:')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '<!-- bot:')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
     runs-on: ubuntu-latest
     permissions:
@@ -216,6 +216,41 @@ jobs:
             # Use --verbose and --output-format stream-json for complete conversation logs
             mkdir -p "${CLAUDE_CONFIG_DIR}"
 
+            # Programmatic bot marker injection: wrap gh so all comments
+            # automatically get the marker appended, regardless of LLM compliance.
+            REAL_GH="$(which gh)"
+            cat > /tmp/gh-wrapper << 'GHWRAPPER'
+            #!/bin/bash
+            MARKER=$'\n<!-- bot:claude-workflow -->'
+            # Intercept 'gh pr comment' and 'gh issue comment' to append marker
+            if { [ "${1:-}" = "pr" ] && [ "${2:-}" = "comment" ]; } || \
+               { [ "${1:-}" = "issue" ] && [ "${2:-}" = "comment" ]; }; then
+              args=()
+              i=1
+              while [ $i -le $# ]; do
+                arg="${!i}"
+                args+=("$arg")
+                if [ "$arg" = "--body" ]; then
+                  i=$((i + 1))
+                  val="${!i}"
+                  # Append marker if not already present
+                  if ! echo "$val" | grep -qF '<!-- bot:claude-workflow -->'; then
+                    val="${val}${MARKER}"
+                  fi
+                  args+=("$val")
+                fi
+                i=$((i + 1))
+              done
+              exec "__REAL_GH__" "${args[@]}"
+            else
+              exec "__REAL_GH__" "$@"
+            fi
+            GHWRAPPER
+            sed -i "s|__REAL_GH__|${REAL_GH}|g" /tmp/gh-wrapper
+            chmod +x /tmp/gh-wrapper
+            export PATH="/tmp:$PATH"
+            ln -sf /tmp/gh-wrapper /tmp/gh
+
             # Build the prompt based on whether this is a PR or issue comment
             if [ "$IS_PR" = "true" ]; then
               PROMPT="You are an autonomous agent responding to a request on PR #${ISSUE_NUMBER} in ${REPO}.
@@ -246,8 +281,8 @@ jobs:
             - Never use \`git push --no-verify\`
 
             COMMENT RULES (to prevent feedback loops):
-            - ALWAYS append the HTML comment <!-- bot:claude-workflow --> at the end of every GitHub comment you post
-            - NEVER include the literal string @claude in any comment body — use 'Claude' (no @) when referring to yourself
+            - The gh wrapper automatically appends the bot marker to your comments
+            - Avoid using @claude as a mention or trigger in comment text — use 'Claude' (no @) when referring to yourself. You may quote or reference the trigger syntax if needed for documentation purposes.
 
             You are on branch ${PR_HEAD_REF}. Make the changes, commit, and push them."
             else
@@ -265,8 +300,8 @@ jobs:
             - Never use \`git push --no-verify\`
 
             COMMENT RULES (to prevent feedback loops):
-            - ALWAYS append the HTML comment <!-- bot:claude-workflow --> at the end of every GitHub comment you post
-            - NEVER include the literal string @claude in any comment body — use 'Claude' (no @) when referring to yourself
+            - The gh wrapper automatically appends the bot marker to your comments
+            - Avoid using @claude as a mention or trigger in comment text — use 'Claude' (no @) when referring to yourself. You may quote or reference the trigger syntax if needed for documentation purposes.
 
             Complete the user's request. If you make changes, create a branch, commit them, and open a PR.
             Reply to the user using: gh issue comment ${ISSUE_NUMBER} --body 'YOUR_RESPONSE'"
@@ -357,6 +392,41 @@ jobs:
             # Use --verbose and --output-format stream-json for complete conversation logs
             mkdir -p "${CLAUDE_CONFIG_DIR}"
 
+            # Programmatic bot marker injection: wrap gh so all comments
+            # automatically get the marker appended, regardless of LLM compliance.
+            REAL_GH="$(which gh)"
+            cat > /tmp/gh-wrapper << 'GHWRAPPER'
+            #!/bin/bash
+            MARKER=$'\n<!-- bot:claude-workflow -->'
+            # Intercept 'gh pr comment' and 'gh issue comment' to append marker
+            if { [ "${1:-}" = "pr" ] && [ "${2:-}" = "comment" ]; } || \
+               { [ "${1:-}" = "issue" ] && [ "${2:-}" = "comment" ]; }; then
+              args=()
+              i=1
+              while [ $i -le $# ]; do
+                arg="${!i}"
+                args+=("$arg")
+                if [ "$arg" = "--body" ]; then
+                  i=$((i + 1))
+                  val="${!i}"
+                  # Append marker if not already present
+                  if ! echo "$val" | grep -qF '<!-- bot:claude-workflow -->'; then
+                    val="${val}${MARKER}"
+                  fi
+                  args+=("$val")
+                fi
+                i=$((i + 1))
+              done
+              exec "__REAL_GH__" "${args[@]}"
+            else
+              exec "__REAL_GH__" "$@"
+            fi
+            GHWRAPPER
+            sed -i "s|__REAL_GH__|${REAL_GH}|g" /tmp/gh-wrapper
+            chmod +x /tmp/gh-wrapper
+            export PATH="/tmp:$PATH"
+            ln -sf /tmp/gh-wrapper /tmp/gh
+
             # Fetch issue body via API to avoid multi-line env var escaping issues
             ISSUE_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.body')
 
@@ -413,8 +483,8 @@ jobs:
               --head claude/issue-${ISSUE_NUMBER}
 
             COMMENT RULES (to prevent feedback loops):
-            - ALWAYS append the HTML comment <!-- bot:claude-workflow --> at the end of every GitHub comment you post
-            - NEVER include the literal string @claude in any comment body — use 'Claude' (no @) when referring to yourself
+            - The gh wrapper automatically appends the bot marker to your comments
+            - Avoid using @claude as a mention or trigger in comment text — use 'Claude' (no @) when referring to yourself. You may quote or reference the trigger syntax if needed for documentation purposes.
 
             If you cannot resolve the issue (unclear requirements, needs human decision, etc.),
             comment on the issue explaining what clarification is needed:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -108,9 +108,9 @@ jobs:
     needs: [authorize, build-devcontainer]
     if: |
       needs.authorize.outputs.authorized == 'true' &&
-      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '<!-- bot:claude-workflow -->')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '<!-- bot:claude-workflow -->')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '<!-- bot:claude-workflow -->')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
     runs-on: ubuntu-latest
     permissions:
@@ -245,6 +245,10 @@ jobs:
             - Reference docs/01-architecture-overview.md for system design context
             - Never use \`git push --no-verify\`
 
+            COMMENT RULES (to prevent feedback loops):
+            - ALWAYS append the HTML comment <!-- bot:claude-workflow --> at the end of every GitHub comment you post
+            - NEVER include the literal string @claude in any comment body — use 'Claude' (no @) when referring to yourself
+
             You are on branch ${PR_HEAD_REF}. Make the changes, commit, and push them."
             else
               PROMPT="You are responding to a request in ${REPO} issue #${ISSUE_NUMBER}.
@@ -259,6 +263,10 @@ jobs:
             - If Cargo.toml exists, use \`cargo clippy -- -D warnings\` for linting
             - Reference docs/01-architecture-overview.md for system design context
             - Never use \`git push --no-verify\`
+
+            COMMENT RULES (to prevent feedback loops):
+            - ALWAYS append the HTML comment <!-- bot:claude-workflow --> at the end of every GitHub comment you post
+            - NEVER include the literal string @claude in any comment body — use 'Claude' (no @) when referring to yourself
 
             Complete the user's request. If you make changes, create a branch, commit them, and open a PR.
             Reply to the user using: gh issue comment ${ISSUE_NUMBER} --body 'YOUR_RESPONSE'"
@@ -403,6 +411,10 @@ jobs:
 
             Generated with Claude Code' \\
               --head claude/issue-${ISSUE_NUMBER}
+
+            COMMENT RULES (to prevent feedback loops):
+            - ALWAYS append the HTML comment <!-- bot:claude-workflow --> at the end of every GitHub comment you post
+            - NEVER include the literal string @claude in any comment body — use 'Claude' (no @) when referring to yourself
 
             If you cannot resolve the issue (unclear requirements, needs human decision, etc.),
             comment on the issue explaining what clarification is needed:

--- a/.github/workflows/review-code-content.yml
+++ b/.github/workflows/review-code-content.yml
@@ -74,6 +74,9 @@ jobs:
             HAS_RUST_CODE=${{ inputs.has_rust_code }}
             HAS_DOCS=${{ inputs.has_docs }}
           runCmd: |
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             claude --print \
               --verbose \
               --output-format stream-json \

--- a/.github/workflows/review-coverage-evaluator.yml
+++ b/.github/workflows/review-coverage-evaluator.yml
@@ -112,6 +112,9 @@ jobs:
             PR_NUMBER=${{ needs.get-pr-context.outputs.pr_number }}
             REPO=${{ github.repository }}
           runCmd: |
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             claude --print \
               --verbose \
               --output-format stream-json \

--- a/.github/workflows/review-crypto.yml
+++ b/.github/workflows/review-crypto.yml
@@ -103,6 +103,9 @@ jobs:
             HEAD_REF=${{ inputs.head_ref }}
             REPO=${{ github.repository }}
           runCmd: |
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             claude --print \
               --verbose \
               --output-format stream-json \

--- a/.github/workflows/review-design.yml
+++ b/.github/workflows/review-design.yml
@@ -131,6 +131,9 @@ jobs:
               ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" --jq '.[] | "---\n**\(.user.login)** commented at \(.created_at):\n\(.body)\n"' 2>/dev/null | head -c 50000 || echo "")
             fi
 
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             claude --print \
               --verbose \
               --output-format stream-json \

--- a/.github/workflows/review-docs.yml
+++ b/.github/workflows/review-docs.yml
@@ -125,6 +125,9 @@ jobs:
             PR_BODY=$(echo "$PR_BODY_B64" | base64 -d 2>/dev/null || echo "")
             ISSUE_BODY=$(echo "$ISSUE_BODY_B64" | base64 -d 2>/dev/null || echo "")
 
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             claude --print \
               --verbose \
               --output-format stream-json \

--- a/.github/workflows/review-rfc-standards.yml
+++ b/.github/workflows/review-rfc-standards.yml
@@ -125,6 +125,9 @@ jobs:
             PR_BODY=$(echo "$PR_BODY_B64" | base64 -d 2>/dev/null || echo "")
             ISSUE_BODY=$(echo "$ISSUE_BODY_B64" | base64 -d 2>/dev/null || echo "")
 
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             claude --print \
               --verbose \
               --output-format stream-json \

--- a/.github/workflows/review-standards.yml
+++ b/.github/workflows/review-standards.yml
@@ -138,6 +138,9 @@ jobs:
             PR_BODY=$(echo "$PR_BODY_B64" | base64 -d 2>/dev/null || echo "")
             ISSUE_BODY=$(echo "$ISSUE_BODY_B64" | base64 -d 2>/dev/null || echo "")
 
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             claude --print \
               --verbose \
               --output-format stream-json \

--- a/.github/workflows/review-test.yml
+++ b/.github/workflows/review-test.yml
@@ -103,6 +103,9 @@ jobs:
             PR_NUMBER=${{ inputs.pr_number }}
             HEAD_REF=${{ inputs.head_ref }}
           runCmd: |
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             # Using Sonnet: Checklist-based review with clear criteria
             claude --print \
               --verbose \

--- a/.github/workflows/weekly-review-crypto.yml
+++ b/.github/workflows/weekly-review-crypto.yml
@@ -52,6 +52,9 @@ jobs:
             GH_TOKEN=${{ github.token }}
             REPO=${{ github.repository }}
           runCmd: |
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             claude --print \
               --verbose \
               --output-format stream-json \

--- a/.github/workflows/weekly-review-security-news.yml
+++ b/.github/workflows/weekly-review-security-news.yml
@@ -52,6 +52,9 @@ jobs:
             GH_TOKEN=${{ github.token }}
             REPO=${{ github.repository }}
           runCmd: |
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             claude --print \
               --verbose \
               --output-format stream-json \

--- a/.github/workflows/weekly-review-standards.yml
+++ b/.github/workflows/weekly-review-standards.yml
@@ -53,6 +53,9 @@ jobs:
             GH_TOKEN=${{ github.token }}
             REPO=${{ github.repository }}
           runCmd: |
+            # Programmatic bot marker injection for feedback loop prevention
+            source .github/scripts/setup-gh-wrapper.sh
+
             claude --print \
               --verbose \
               --output-format stream-json \


### PR DESCRIPTION
## Summary

- Add `<!-- bot:claude-workflow -->` marker filter to the `claude` job's `if` condition so bot-authored comments are rejected as triggers
- Add deterministic `user.type != 'Bot'` check to all comment-based trigger conditions as a fallback mechanism
- Add programmatic gh wrapper to inject bot marker into all comments automatically, regardless of LLM compliance
- Add prompt instructions for all three jobs (claude PR, claude issue, resolve-issue) to avoid using `@claude` as a trigger in comment text
- Leave the `issues` event path unchanged since only comments loop back

## Test plan

- [ ] Verify the marker filter is correctly placed in all three comment-based event conditions (`issue_comment`, `pull_request_review_comment`, `pull_request_review`)
- [ ] Verify the `user.type != 'Bot'` check is present on all comment-based trigger conditions
- [ ] Verify the `issues` event path does NOT have the marker or bot-type filter (not needed)
- [ ] Confirm a comment from `github-actions[bot]` would NOT trigger the workflow (deterministic check)
- [ ] Confirm a comment containing both `@claude` and `<!-- bot:claude-workflow -->` would NOT match the new condition (marker check)
- [ ] Verify the gh wrapper programmatically injects the bot marker into all `gh pr comment` and `gh issue comment` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)